### PR TITLE
Update scrape-img-qr.ts

### DIFF
--- a/src/api/helpers/scrape-img-qr.ts
+++ b/src/api/helpers/scrape-img-qr.ts
@@ -24,7 +24,7 @@ export async function scrapeImg(page: Page): Promise<ScrapQrcode | undefined> {
       const selectorImg = document.querySelector('canvas');
       const selectorUrl = selectorImg.closest('[data-ref]');
       //const buttonReload = selectorUrl.querySelector('[role="button"]') as HTMLButtonElement;
-      const buttonReload = selectorUrl.querySelector('[data-testid="refresh-large"]');
+      const buttonReload = selectorUrl.querySelector('button');
       if (buttonReload != null) {
         buttonReload.click();
         return true;

--- a/src/api/helpers/scrape-img-qr.ts
+++ b/src/api/helpers/scrape-img-qr.ts
@@ -23,9 +23,8 @@ export async function scrapeImg(page: Page): Promise<ScrapQrcode | undefined> {
     .evaluate(() => {
       const selectorImg = document.querySelector('canvas');
       const selectorUrl = selectorImg.closest('[data-ref]');
-      const buttonReload = selectorUrl.querySelector(
-        '[role="button"]'
-      ) as HTMLButtonElement;
+      //const buttonReload = selectorUrl.querySelector('[role="button"]') as HTMLButtonElement;
+      const buttonReload = selectorUrl.querySelector('[data-testid="refresh-large"]');
       if (buttonReload != null) {
         buttonReload.click();
         return true;


### PR DESCRIPTION
Fix click to reload qr code

Fixes # .

## Changes proposed in this pull request

```node
//const buttonReload = selectorUrl.querySelector('[role="button"]') as HTMLButtonElement;
const buttonReload = selectorUrl.querySelector('button');
```
