### PR TITLE
Trocar Ordem de Mensagem

### DIFF
--- a/src/lib/wapi/functions/send-link-preview.js
+++ b/src/lib/wapi/functions/send-link-preview.js
@@ -45,7 +45,7 @@ export async function sendLinkPreview(chatId, url, text) {
   if (!chat.erro) {
     const linkPreview = await Store.WapQuery.queryLinkPreview(url);
     var result =
-      (await chat.sendMessage(text.includes(url) ? text : `${url}\n${text}`, {
+      (await chat.sendMessage(text.includes(url) ? text : `*${text}*\n${url}`, {
         linkPreview,
       })) || '';
     var m = { type: 'LinkPreview', url: url, text: text },


### PR DESCRIPTION
Inves de enviar o link e depois o texto, invertendo e colocando o texto em negrito, para que na notificação do contato, inves de aparecer o link, apareça o texto antes.

Fixes # .

## Changes proposed in this pull request

-
-

To test (it takes a while): `npm install github:<username>/wppconnect#<branch>`
