### PR TITLE
Fixed: cannot read property includes of undefined

### DIFF
--- a/src/lib/wapi/functions/check-send-exist.js
+++ b/src/lib/wapi/functions/check-send-exist.js
@@ -40,6 +40,11 @@ export async function getchatId(chatId) {
 }
 
 export async function sendExist(chatId, returnChat = true, Send = true) {
+  
+  // Prevent error: cannot read property includes of undefined 
+  // ... when chatId is undefined 
+  if (!chatId) return scope(chatId, true, 404, 'Invalid chat id'); 
+  
   // Check chat exists (group is always a chat)
   let chat = await window.WAPI.getChat(chatId);
 


### PR DESCRIPTION
Fixes # When chatId parameter is passed with undefined value, the function raised unhandled exception up into the stack and NodeJs exits the process. I fixed it checking if chatId is not undefined at the beginning of the function.

## Changes proposed in this pull request
Defensive code

