### PR TITLE
Correção ao obter id ao enviar mensagens de midia

### DIFF
--- a/src/lib/wapi/functions/get-chat-by-id.js
+++ b/src/lib/wapi/functions/get-chat-by-id.js
@@ -15,8 +15,8 @@
  * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export function getChatById(id, done) {
-  let found = WAPI.getChat(id);
+export async function getChatById(id, done) {
+  let found = await WAPI.getChat(id);
   if (found) {
     found = WAPI._serializeChatObj(found);
   } else {


### PR DESCRIPTION
Correção nos metodos sendImage e sendFile, ambos estavam retornando id da mensagem anterior como resposta.