### PR TITLE
feat: options for GA and linkPreviewApiServers

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -140,6 +140,9 @@ export class HostLayer {
 
     const options = {
       deviceName: this.options.deviceName,
+      disableGoogleAnalytics: this.options.disableGoogleAnalytics,
+      googleAnalyticsId: this.options.googleAnalyticsId,
+      linkPreviewApiServers: this.options.linkPreviewApiServers,
     };
 
     await evaluateAndReturn(

--- a/src/config/create-config.ts
+++ b/src/config/create-config.ts
@@ -136,7 +136,27 @@ export interface CreateConfig {
    * @default 'WPPConnect'
    */
   deviceName?: string | false;
+
+  /**
+   * Set custom Link Preview API servers
+   * @default null
+   */
+  linkPreviewApiServers?: string[] | null;
+
+  /**
+   * Disable custom Google Analytics
+   * @default true
+   */
+  disableGoogleAnalytics?: boolean;
+
+  /**
+   * Custom Google Analytics Tracker Id, like 'G-XXXXXXXXXX'
+   * collect analytics data to your GA account
+   * @default null
+   */
+  googleAnalyticsId?: string | null;
 }
+
 export const defaultOptions: CreateConfig = {
   folderNameToken: './tokens',
   headless: true,
@@ -156,4 +176,7 @@ export const defaultOptions: CreateConfig = {
   tokenStore: 'file',
   whatsappVersion: '2.2220.x',
   deviceName: false,
+  linkPreviewApiServers: null,
+  disableGoogleAnalytics: true,
+  googleAnalyticsId: null,
 };


### PR DESCRIPTION

append to options of WPPConfig for working with wa-js, but not work. What must I change?