### PR TITLE
feat: Loading Screen callback function with percent and message

### DIFF
--- a/docs/getting-started/creating-client.md
+++ b/docs/getting-started/creating-client.md
@@ -46,6 +46,9 @@ wppconnect.create({
       //Create session wss return "serverClose" case server for close
       console.log('Session name: ', session);
     },
+    onLoadingScreen: (percent, message) => {
+      console.log('LOADING_SCREEN', percent, message);
+    },
     headless: true, // Headless chrome
     devtools: false, // Open devtools by default
     useChrome: true, // If false will use Chromium instance

--- a/examples/bot-functions/index.js
+++ b/examples/bot-functions/index.js
@@ -17,7 +17,12 @@
 const wppconnect = require('../../dist');
 
 wppconnect
-  .create()
+  .create({
+    session: 'teste',
+    onLoadingScreen: (percent, message) => {
+      console.log('LOADING_SCREEN', percent, message);
+    },
+  })
   .then((client) => start(client))
   .catch((erro) => {
     console.log(erro);

--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -31,7 +31,12 @@ import {
 import { sleep } from '../../utils/sleep';
 import { defaultLogger, LogLevel } from '../../utils/logger';
 import { Logger } from 'winston';
-import { CatchQRCallback, HostDevice, StatusFindCallback } from '../model';
+import {
+  CatchQRCallback,
+  HostDevice,
+  LoadingScreenCallback,
+  StatusFindCallback,
+} from '../model';
 import {
   FileTokenStore,
   isValidSessionToken,
@@ -49,6 +54,8 @@ export class HostLayer {
   protected autoCloseInterval = null;
   protected autoCloseCalled = false;
   protected statusFind?: StatusFindCallback = null;
+
+  public onLoadingScreen?: LoadingScreenCallback = null;
 
   constructor(public page: Page, session?: string, options?: CreateConfig) {
     this.session = session;
@@ -122,7 +129,8 @@ export class HostLayer {
       this.page,
       sessionToken,
       clear,
-      this.options.whatsappVersion
+      this.options.whatsappVersion,
+      this.onLoadingScreen
     );
 
     this.page.on('load', () => {

--- a/src/api/model/initializer.ts
+++ b/src/api/model/initializer.ts
@@ -36,6 +36,11 @@ export type StatusFindCallback = (
   session: string
 ) => void;
 
+/**
+ * A callback will be received, informing data as percentage and loading screen message
+ */
+export type LoadingScreenCallback = (percent: number, message: string) => void;
+
 export interface CreateOptions extends CreateConfig {
   /**
    * You must pass a string type parameter, this parameter will be the name of the client's session. If the parameter is not passed, the section name will be "session".
@@ -49,6 +54,11 @@ export interface CreateOptions extends CreateConfig {
    * A callback will be received, informing the customer's status
    */
   statusFind?: StatusFindCallback;
+
+  /**
+   * A callback will be received, informing data as percentage and loading screen message
+   */
+  onLoadingScreen?: LoadingScreenCallback;
   /**
    * Pass the session token information you can receive this token with the await client.getSessionTokenBrowser () function
    * @deprecated in favor of `sessionToken`

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -110,8 +110,8 @@ export async function initWhatsapp(
   return page;
 }
 
-var lastPercent = null;
-var lastPercentMessage = null;
+let lastPercent = null;
+let lastPercentMessage = null;
 export async function onLoadingScreen(
   page: Page,
   onLoadingScreenCallBack?: LoadingScreenCallback
@@ -133,7 +133,7 @@ export async function onLoadingScreen(
 
   await page.evaluate(
     function (selectors) {
-      var observer = new MutationObserver(function () {
+      let observer = new MutationObserver(function () {
         let window2: any = window;
 
         let progressBar = window2.getElementByXpath(selectors.PROGRESS);

--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -24,6 +24,7 @@ import { Browser } from 'puppeteer';
 import {
   CatchQRCallback,
   CreateOptions,
+  LoadingScreenCallback,
   StatusFindCallback,
 } from '../api/model/initializer';
 import { SessionToken } from '../token-store';
@@ -65,6 +66,7 @@ export async function create(
   sessionName: string,
   catchQR?: CatchQRCallback,
   statusFind?: StatusFindCallback,
+  onLoadingScreen?: LoadingScreenCallback,
   options?: CreateConfig,
   browserSessionToken?: SessionToken
 ): Promise<Whatsapp>;
@@ -73,6 +75,7 @@ export async function create(
   sessionOrOption: string | CreateOptions,
   catchQR?: CatchQRCallback,
   statusFind?: StatusFindCallback,
+  onLoadingScreen?: LoadingScreenCallback,
   options?: CreateConfig,
   browserSessionToken?: SessionToken
 ): Promise<Whatsapp> {
@@ -96,6 +99,7 @@ export async function create(
     session = sessionOrOption.session;
     catchQR = sessionOrOption.catchQR || catchQR;
     statusFind = sessionOrOption.statusFind || statusFind;
+    onLoadingScreen = sessionOrOption.onLoadingScreen || onLoadingScreen;
 
     if (!options.sessionToken) {
       options.sessionToken =
@@ -227,6 +231,7 @@ export async function create(
 
   if (page) {
     const client = new Whatsapp(page, session, mergedOptions);
+    client.onLoadingScreen = onLoadingScreen;
 
     if (mergedOptions.waitForLogin) {
       const isLogged = await client.waitForLogin(catchQR, statusFind);


### PR DESCRIPTION
It will help a lot of people who need this whatsapp screen status.

When the screen is loading, the callback function 'onLoadingScreen' is called with two parameters:
percent: number
message: string

![loading-screen](https://user-images.githubusercontent.com/106827778/178314243-c09e6bd6-1dfb-4bd2-813e-a9b49320acdd.png)

To test (it takes a while): `npm install github:tonbotfy/wppconnect`

**_wppconnect
  .create({
    session: 'teste',
    onLoadingScreen: (percent, message) => {
      console.log('LOADING_SCREEN', percent, message);
    },
  })_**


