### PR TITLE
fix: Fixed WAPI is not defined (fix wppconnect-team/wppconnect-server#864)

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -129,8 +129,7 @@ export class HostLayer {
       this.page,
       sessionToken,
       clear,
-      this.options.whatsappVersion,
-      this.onLoadingScreen
+      this.options.whatsappVersion
     );
 
     this.page.on('load', () => {
@@ -162,7 +161,7 @@ export class HostLayer {
       options
     );
 
-    await injectApi(this.page)
+    await injectApi(this.page, this.onLoadingScreen)
       .then(() => {
         this.log('verbose', 'wapi.js injected');
         this.getWAVersion()

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -85,8 +85,7 @@ export async function initWhatsapp(
   page: Page,
   token?: SessionToken,
   clear = true,
-  version?: string,
-  onLoadingScreenCallBack?: LoadingScreenCallback
+  version?: string
 ) {
   await page.setUserAgent(useragentOverride);
 
@@ -104,8 +103,6 @@ export async function initWhatsapp(
       waitUntil: 'domcontentloaded',
     })
     .catch(() => {});
-
-  await onLoadingScreen(page, onLoadingScreenCallBack);
 
   return page;
 }
@@ -167,7 +164,10 @@ export async function onLoadingScreen(
   );
 }
 
-export async function injectApi(page: Page) {
+export async function injectApi(
+  page: Page,
+  onLoadingScreenCallBack?: LoadingScreenCallback
+) {
   const injected = await page
     .evaluate(() => {
       // @ts-ignore
@@ -209,6 +209,7 @@ export async function injectApi(page: Page) {
     ),
   });
 
+  await onLoadingScreen(page, onLoadingScreenCallBack);
   // Make sure WAPI is initialized
   return await page
     .waitForFunction(() => {


### PR DESCRIPTION
A função estava sendo chamada antes do WAPI ser carregado no browser, então, em alguns momentos ocasionava erro de WAPI no WppConnect-Server