### PR TITLE
fix: page on load order

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -125,13 +125,6 @@ export class HostLayer {
 
     let clear = !hasUserDataDir || (hasUserDataDir && !isValidToken);
 
-    await initWhatsapp(
-      this.page,
-      sessionToken,
-      clear,
-      this.options.whatsappVersion
-    );
-
     this.page.on('load', () => {
       this.log('verbose', 'Page loaded', { type: 'page' });
       this.afterPageLoad();
@@ -140,6 +133,13 @@ export class HostLayer {
       this.cancelAutoClose();
       this.log('verbose', 'Page Closed', { type: 'page' });
     });
+
+    await initWhatsapp(
+      this.page,
+      sessionToken,
+      clear,
+      this.options.whatsappVersion
+    );
   }
 
   protected async afterPageLoad() {


### PR DESCRIPTION
Fixes #1335.

When the whatsweb page load with a token already set, it's look like the page.on('load') is firing before the event is set