### PR TITLE
fix: Fixed Puppeteer error and undefined sendList

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "logform": "^2.4.2",
     "lookpath": "^1.2.2",
     "mime-types": "^2.1.35",
-    "puppeteer": "*",
+    "puppeteer": "^19.4.0",
     "puppeteer-extra": "^3.3.4",
     "puppeteer-extra-plugin-stealth": "^2.11.1",
     "puppeteer-extra-plugin-user-data-dir": "^2.4.0",

--- a/src/api/helpers/evaluate-and-return.ts
+++ b/src/api/helpers/evaluate-and-return.ts
@@ -15,12 +15,15 @@
  * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Page } from 'puppeteer';
+
 import {
   EvaluateFn,
   EvaluateFnReturnType,
-  Page,
   SerializableOrJSHandle,
-} from 'puppeteer';
+} from '../../types/Evaluate';
+
+//EvaluateFn, EvaluateFnReturnType, SerializableOrJSHandle //
 
 export async function evaluateAndReturn<T extends EvaluateFn>(
   page: Page,

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -25,7 +25,7 @@ import { sleep } from '../utils/sleep';
 
 export const getInterfaceStatus = async (
   waPage: puppeteer.Page
-): Promise<string | null> => {
+): Promise<puppeteer.HandleFor<Awaited<ReturnType<any>>>> => {
   return await waPage
     .waitForFunction(
       () => {
@@ -52,8 +52,10 @@ export const getInterfaceStatus = async (
         polling: 100,
       }
     )
-    .then(async (element) => {
-      return (await element.evaluate((a) => a)) as string;
+    .then(async (element: puppeteer.HandleFor<Awaited<ReturnType<any>>>) => {
+      return (await element.evaluate((a: any) => a)) as puppeteer.HandleFor<
+        ReturnType<any>
+      >;
     })
     .catch(() => null);
 };
@@ -160,7 +162,7 @@ export async function injectSessionToken(
   await page.goto(puppeteerConfig.whatsappUrl + '?_=' + Date.now());
 
   if (clear) {
-    await page.evaluate((session) => {
+    await page.evaluate(() => {
       if (document.title !== 'Initializing WhatsApp') {
         return;
       }

--- a/src/types/Evaluate.d.ts
+++ b/src/types/Evaluate.d.ts
@@ -1,0 +1,28 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export declare type EvaluateFn<T = any, U = any, V = any> =
+  | string
+  | ((arg1: T, ...args: U[]) => V);
+
+export declare type EvaluateFnReturnType<T extends EvaluateFn> = T extends (
+  ...args: any[]
+) => infer R
+  ? R
+  : any;
+
+export declare type SerializableOrJSHandle = Serializable | JSHandle;


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

No primeiro comit corrigi os tipos de retorno do Puppeteer que bloqueavam a build da LIB, à partir da versão 14.4.1 do Pupeteer foi excluido a exporação dos tipos e são auto-deduzidos, para manter a mesma função, copiei os tipos do código original do Pupeteer, e coloquei o retorno seguindo o mesmo padrão desse PR: https://github.com/puppeteer/puppeteer/pull/8547

No segundo comit é a correção de erro que dava undefined no retorno da mensagem, ao enviar uma Lista.

-
-

To test (it takes a while): `npm install github:icleitoncosta/wppconnect#<branch>`
