### PR TITLE
fix: Reverting to previous fix as a temporary workaround

### DIFF
--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -281,8 +281,12 @@ export async function initBrowser(
     const transport = await getTransport(options.browserWS);
     browser = await puppeteer.connect({ transport });
   } else {
+    /**
+     * Setting the headless mode to the old Puppeteer mode, when using the 'new' mode, results in an error on CentOS7 and Debian11.
+     * Temporary fix.
+     */
     browser = await puppeteer.launch({
-      headless: options.headless ? 'new' : false,
+      headless: options.headless,
       devtools: options.devtools,
       args: options.browserArgs
         ? options.browserArgs


### PR DESCRIPTION
This commit reverts to a previous fix as a temporary workaround. The issue encountered on CentOS7 and Debian11 when using the 'new' mode in Puppeteer's headless mode requires further investigation and a more comprehensive solution. By reverting to the previous fix, we aim to restore functionality and address the immediate problem. Future updates will address the underlying issue appropriately.