### PR TITLE
feat: add poll_creation to message types

### DIFF
--- a/src/api/model/enum/message-type.ts
+++ b/src/api/model/enum/message-type.ts
@@ -51,6 +51,7 @@ export enum MessageType {
   LIST = 'list',
   LIST_RESPONSE = 'list_response',
   BUTTONS_RESPONSE = 'buttons_response',
+  POLL_CREATION = 'poll_creation',
   UNKNOWN = 'unknown',
 }
 


### PR DESCRIPTION
Fixes # .

## Changes proposed in this pull request

-
-

The poll_creation label to message types are missing, this PR just create this message type.
