### PR TITLE
fix: Fixed main-frame crash

### DIFF
--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -116,7 +116,14 @@ export async function initWhatsapp(
     await setWhatsappVersion(page, version, log);
   }
 
-  setTimeout(() => {
+  log?.('verbose', `Loading WhatsApp WEB`);
+  await page.goto(puppeteerConfig.whatsappUrl, {
+    waitUntil: 'load',
+    timeout: 0,
+    referer: 'https://whatsapp.com/',
+  });
+  log?.('verbose', 'WhatsApp WEB loaded');
+  /*setTimeout(() => {
     log?.('verbose', `Loading WhatsApp WEB`);
 
     const timeout = 10 * 1000;
@@ -129,6 +136,7 @@ export async function initWhatsapp(
 
     log?.('verbose', `WhatsApp WEB loaded`);
   }, 1000);
+  */
 
   return page;
 }


### PR DESCRIPTION
The use of setTimeout and delay within Puppeteer causes some crashes, especially the 'Error: Requesting main frame too early!' error. The intention here is to remove these errors. From my point of view, the use of these timeouts is not necessary based on my tests. However, it would be interesting to have an analysis from whoever created them to be sure.