### PR TITLE
fix: Bypass content-security-policy errors

### DIFF
--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -235,6 +235,8 @@ export async function create(
   }
 
   if (page) {
+    await page.setBypassCSP(true);
+    
     const client = new Whatsapp(page, session, mergedOptions);
     client.catchQR = catchQR;
     client.statusFind = statusFind;

--- a/src/controllers/initializer.ts
+++ b/src/controllers/initializer.ts
@@ -236,7 +236,7 @@ export async function create(
 
   if (page) {
     await page.setBypassCSP(true);
-    
+
     const client = new Whatsapp(page, session, mergedOptions);
     client.catchQR = catchQR;
     client.statusFind = statusFind;


### PR DESCRIPTION
Fixes #2109 

## Changes proposed in this pull request

Bypass recent Content-Security-Policy restrictions on recent WhatsApp Web versions.

To test (it takes a while): `npm install github:renandecarlo/wppconnect#renandecarlo-patch-1`
