### PR TITLE
doc(#2188): invalid start client command in the documentation

### DIFF
--- a/docs/getting-started/basic-functions.md
+++ b/docs/getting-started/basic-functions.md
@@ -1,4 +1,4 @@
-# Basic Functions (usage)
+# Basic functions (usage)
 
 Not every available function will be listed, for further look, every function
 available can be found in {@link Whatsapp}
@@ -96,7 +96,7 @@ await client
 
 ### sendLinkPreview
 
-Automatically sends a link with the auto generated link preview. You can also add a custom message to be added.
+Automatically sends a link with the auto-generated link preview. You can also add a custom message to be added.
 
 ```javascript
 await client
@@ -135,7 +135,7 @@ await client
 
 ### sendFile
 
-Send a file (wppconnect will take care of mime types, just need the path).\
+Send a file (wppconnect will take care of mime types, just needs the path).\
 You can also upload an image using a valid HTTP protocol
 
 ```javascript
@@ -178,8 +178,8 @@ await client
 
 ### sendImageAsStickerGif
 
-Generates a sticker from the provided animated gif image and sends it (Send an image as animated sticker)\
-Image path imageBase64 A valid gif and webp image will be required. You can also send via http/https (<http://www.website.com/img.gif>)
+Generates a sticker from the provided animated gif image and sends it (Send an image as an animated sticker)\
+Image path imageBase64 A valid gif and webp image will be required. You can also send it via HTTP/HTTPS (<http://www.website.com/img.gif>)
 
 ```javascript
 await client
@@ -194,8 +194,8 @@ await client
 
 ### sendImageAsSticker
 
-Generates a sticker from given image and sends it (Send Image As Sticker)\
-image path imageBase64 A valid png, jpg and webp image will be required. You can also send via http/https (<http://www.website.com/img.jpg>)
+Generates a sticker from a given image and sends it (Send Image As Sticker)\
+image path imageBase64 A valid PNG, JPG, and WebP image will be required. You can also send it via HTTP/HTTPS (<http://www.website.com/img.jpg>)
 
 ```javascript
 await client
@@ -234,7 +234,7 @@ await client.reply(
 
 ### reply with mention
 
-Reply to a message with mention
+Reply to a message with a mention
 
 ```javascript
 await client.reply(

--- a/docs/getting-started/configuring-logger.md
+++ b/docs/getting-started/configuring-logger.md
@@ -1,10 +1,10 @@
 # Configuring the logger
 
-`Wppconnect Bot` use [winston](https://github.com/winstonjs/winston) package for log management.
+`Wppconnect Bot` uses the [winston](https://github.com/winstonjs/winston) package for log management.
 
-`wppconnect.defaultLogger` is a instance of `winston.createLogger`.
+`wppconnect.defaultLogger` is an instance of `winston.createLogger`.
 
-## Default Log level
+## Default log level
 
 The default log level is `info`
 
@@ -17,11 +17,11 @@ const wppconnect = require('@wppconnect-team/wppconnect');
 // All logs: 'silly'
 wppconnect.defaultLogger.level = 'silly';
 
-// If you want stop console logging
+// If you want to stop console logging
 wppconnect.defaultLogger.transports.forEach((t) => (t.silent = true));
 ```
 
-## Using a custon logger
+## Using a custom logger
 
 ```javascript
 // Supports ES6
@@ -50,7 +50,7 @@ wppconnect
     logger: logger,
   })
   .then((client) => {
-    start(client);
+    client.start();
   })
   .catch((erro) => {
     console.log(erro);
@@ -59,7 +59,7 @@ wppconnect
 
 ## Log to file
 
-By default, wppconnect use the Console transport for logging.
+By default, wppconnect uses the Console transport for logging.
 
 If you want to save the log to a file, you can configure
 using the [winston transport](https://github.com/winstonjs/winston#transports)
@@ -78,10 +78,10 @@ wppconnect.defaultLogger.clear(); // Remove all transports
 const files = new winston.transports.File({ filename: 'combined.log' });
 wppconnect.defaultLogger.add(files); // Add file transport
 
-// Optinal: create a custom console with error level
+//Optional: create a custom console with error level
 const console = new winston.transports.Console({ level: 'erro' });
 wppconnect.defaultLogger.add(console); // Add console transport
 
-// Optinal: Remove the custom transport
+//Optional: Remove the custom transport
 wppconnect.defaultLogger.remove(console); // Remove console transport
 ```

--- a/docs/getting-started/creating-client.md
+++ b/docs/getting-started/creating-client.md
@@ -1,7 +1,7 @@
 # Creating a Client
 
-To start using `Wppconnect Bot`, you need to create a file and call the {@link create} method.\
-That method returns an `Promise` of {@link Whatsapp}.
+To start using `Wppconnect Bot`, create a file and call the {@link create} method.\
+That method returns a `Promise` of {@link Whatsapp}.
 
 ```javascript
 // Supports ES6
@@ -10,7 +10,7 @@ const wppconnect = require('@wppconnect-team/wppconnect');
 
 wppconnect
   .create()
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 ```
 
@@ -21,11 +21,11 @@ in case you have different departments in your project,
 then you had to specify it in your code like in that example:
 
 ```javascript
-// Init sales whatsapp bot
-wppconnect.create({session: 'sales'}).then((client) => startClient(client));
+// Init sales WhatsApp bot
+wppconnect.create({session: 'sales'}).then((client) => client.start());
 
-// Init support whatsapp bot
-wppconnect.create({session: 'support'}).then((client) => startSupport(client));
+// Init support WhatsApp bot
+wppconnect.create({session: 'support'}).then((client) => client.start());
 ```
 
 ## Passing options on create
@@ -49,21 +49,21 @@ wppconnect.create({
     onLoadingScreen: (percent, message) => {
       console.log('LOADING_SCREEN', percent, message);
     },
-    headless: true, // Headless chrome
+    headless: true, // Headless Chrome
     devtools: false, // Open devtools by default
     useChrome: true, // If false will use Chromium instance
     debug: false, // Opens a debug session
     logQR: true, // Logs QR automatically in terminal
-    browserWS: '', // If u want to use browserWSEndpoint
-    browserArgs: [''], // Parameters to be added into the chrome browser instance
+    browserWS: '', // If you want to use browserWSEndpoint
+    browserArgs: [''], // Parameters to be added into the Chrome browser instance
     puppeteerOptions: {}, // Will be passed to puppeteer.launch
     disableWelcome: false, // Option to disable the welcoming message which appears in the beginning
     updatesLog: true, // Logs info updates automatically in terminal
     autoClose: 60000, // Automatically closes the wppconnect only when scanning the QR code (default 60 seconds, if you want to turn it off, assign 0 or false)
-    tokenStore: 'file', // Define how work with tokens, that can be a custom interface
+    tokenStore: 'file', // Define how to work with tokens, which can be a custom interface
     folderNameToken: './tokens', //folder name when saving tokens
     // BrowserSessionToken
-    // To receive the client's token use the function await clinet.getSessionTokenBrowser()
+    // To receive the client's token use the function await client.getSessionTokenBrowser()
     sessionToken: {
       WABrowserId: '"UnXjH....."',
       WASecretBundle: '{"key":"+i/nRgWJ....","encKey":"kGdMR5t....","macKey":"+i/nRgW...."}',
@@ -71,7 +71,7 @@ wppconnect.create({
       WAToken2: '"1@lPpzwC...."',
     }
   })
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 ```
 
@@ -103,7 +103,7 @@ wppconnect
       console.log('Session name: ', session);
     },
   })
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 ```
 
@@ -122,8 +122,8 @@ client.stopPhoneWatchdog();
 
 ### Exporting QR Code
 
-By default, QR code will appear on the terminal. If you need to pass the QR
-somewhere else heres how (See {@link CatchQRCallback}):
+By default, a QR code will appear on the terminal. If you need to pass the QR
+somewhere else here is how (See {@link CatchQRCallback}):
 
 ```javascript
 const fs = require('fs');
@@ -157,7 +157,7 @@ wppconnect
     },
     logQR: false,
   })
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 ```
 
@@ -167,10 +167,10 @@ Read the {@link TokenStore}
 
 ### Multidevice (BETA)
 
-To use multidevice account, you have to setup a fixed user data dir for browser to keep it logged,
-because WhatsApp changed the way of autentication.
+To use multidevice account, you have to set a fixed user data dir for the browser to keep it logged,
+because WhatsApp changed the way of authentication.
 
-To setup this, you can use the example bellow:
+To setup this, you can use the example below:
 
 ```javascript
 wppconnect
@@ -182,7 +182,7 @@ wppconnect
     },
     // ...
   })
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 ```
 

--- a/docs/getting-started/receiving-messages.md
+++ b/docs/getting-started/receiving-messages.md
@@ -9,7 +9,7 @@ const wppconnect = require('@wppconnect-team/wppconnect');
 
 wppconnect
   .create()
-  .then((client) => start(client))
+  .then((client) => client.start())
   .catch((error) => console.log(error));
 
 function start(client) {

--- a/docs/getting-started/receiving-messages.md
+++ b/docs/getting-started/receiving-messages.md
@@ -25,5 +25,6 @@ function start(client) {
         });
     }
   });
+  client.start()
 }
 ```


### PR DESCRIPTION
Fixes #2188. as described there, using the code like this results ina `ReferenceError: start is not defined`

Also removed a few typos and grammar mistakes. Disclaimer: I'm not a native speaker.

I also saw `Brazil` being spelled as `Brasil` [here](https://wppconnect.io/docs/tutorial/basics/basic-functions#sendlocation) but that could be intentional. If countries need to be specified in English, then it would have to be `Brazil`. Not sure what the API requires.
