### PR TITLE
feat: added type definitions for incoming calls

### DIFF
--- a/src/api/layers/listener.layer.ts
+++ b/src/api/layers/listener.layer.ts
@@ -28,6 +28,7 @@ import {
   ParticipantEvent,
   PresenceEvent,
   Wid,
+  IncomingCall,
 } from '../model';
 import { MessageType, SocketState, SocketStream } from '../model/enum';
 import { InterfaceMode } from '../model/enum/interface-mode';
@@ -501,18 +502,16 @@ export class ListenerLayer extends ProfileLayer {
   }
 
   /**
-   * @event Escuta por ligações recebidas, seja de áudio ou vídeo.
-   *
-   * Para recusar a ligação, basta chamar o `rejectCall` {@link rejectCall}
-   *
-   * @returns Objeto descartável para parar de ouvir
+   * @event Listen for incoming calls, whether audio or video (pending a reaction).
+   * To reject the call, simply call `rejectCall` {@link rejectCall}
+   * @returns Disposable object to stop listening
    */
-  public onIncomingCall(callback: (call: any) => any) {
+  public onIncomingCall(callback: (call: IncomingCall) => any) {
     return this.registerEvent('onIncomingCall', callback);
   }
 
   /**
-   * Listens to presence changed, by default, it will triggered for active chats only or contacts subscribed (see {@link subscribePresence})
+   * Listens to presence changed, by default, it will be triggered for active chats only or contacts subscribed (see {@link subscribePresence})
    * @event Listens to presence changed
    * @param callback Callback of on presence changed
    * @returns Disposable object to stop the listening

--- a/src/api/model/contact.ts
+++ b/src/api/model/contact.ts
@@ -37,13 +37,13 @@ export interface Contact {
   msgs: any;
 
   /**
-   * Name of contact in your agenda
+   * Name of the contact in your agenda
    */
   name?: string;
   plaintextDisabled: boolean;
 
   /**
-   * @deprecated Depreciated in favor of the function `getProfilePicFromServer` {@link getProfilePicFromServer}
+   * @deprecated Deprecated in favor of the function `getProfilePicFromServer` {@link getProfilePicFromServer}
    */
   profilePicThumbObj: ProfilePicThumbObj;
 

--- a/src/api/model/contact.ts
+++ b/src/api/model/contact.ts
@@ -37,13 +37,13 @@ export interface Contact {
   msgs: any;
 
   /**
-   * Name of concat in your agenda
+   * Name of contact in your agenda
    */
   name?: string;
   plaintextDisabled: boolean;
 
   /**
-   * @deprecated Depreciado em favor da função {@link getProfilePicFromServer}
+   * @deprecated Depreciated in favor of the function `getProfilePicFromServer` {@link getProfilePicFromServer}
    */
   profilePicThumbObj: ProfilePicThumbObj;
 

--- a/src/api/model/incoming-call.ts
+++ b/src/api/model/incoming-call.ts
@@ -1,0 +1,34 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export interface IncomingCall {
+  /** alphanumeric ID of the call, can e.g. usable for hanging up */
+  id: string,
+  /** ID of the caller, can be used to message them directly */
+  peerJid: string,
+  /** Epoch timestamp (seconds) */
+  offerTime: number,
+  isVideo: boolean,
+  isGroup: boolean,
+  groupJid: string | null,
+  canHandleLocally: boolean,
+  outgoing: boolean,
+  isSilenced: boolean,
+  offerReceivedWhileOffline: boolean,
+  webClientShouldHandle: boolean,
+  participants: any[]
+}

--- a/src/api/model/incoming-call.ts
+++ b/src/api/model/incoming-call.ts
@@ -17,18 +17,18 @@
 
 export interface IncomingCall {
   /** alphanumeric ID of the call, can e.g. usable for hanging up */
-  id: string,
+  id: string;
   /** ID of the caller, can be used to message them directly */
-  peerJid: string,
+  peerJid: string;
   /** Epoch timestamp (seconds) */
-  offerTime: number,
-  isVideo: boolean,
-  isGroup: boolean,
-  groupJid: string | null,
-  canHandleLocally: boolean,
-  outgoing: boolean,
-  isSilenced: boolean,
-  offerReceivedWhileOffline: boolean,
-  webClientShouldHandle: boolean,
+  offerTime: number;
+  isVideo: boolean;
+  isGroup: boolean;
+  groupJid: string | null;
+  canHandleLocally: boolean;
+  outgoing: boolean;
+  isSilenced: boolean;
+  offerReceivedWhileOffline: boolean;
+  webClientShouldHandle: boolean;
   participants: any[]
 }

--- a/src/api/model/incoming-call.ts
+++ b/src/api/model/incoming-call.ts
@@ -30,5 +30,5 @@ export interface IncomingCall {
   isSilenced: boolean;
   offerReceivedWhileOffline: boolean;
   webClientShouldHandle: boolean;
-  participants: any[]
+  participants: any[];
 }

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -28,7 +28,7 @@ export { LiveLocation } from './live-location';
 export { ContactStatus } from './contact-status';
 export { GroupCreation } from './group-creation';
 export { WhatsappProfile } from './whatsapp-profile';
-export { IncomingCall } from '.incoming-call';
+export { IncomingCall } from './incoming-call';
 export * from './result';
 export * from './get-messages-param';
 export * from './initializer';

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -28,6 +28,7 @@ export { LiveLocation } from './live-location';
 export { ContactStatus } from './contact-status';
 export { GroupCreation } from './group-creation';
 export { WhatsappProfile } from './whatsapp-profile';
+export { IncomingCall } from '.incoming-call';
 export * from './result';
 export * from './get-messages-param';
 export * from './initializer';


### PR DESCRIPTION
It's typed based on what I know and the data I received in a testing call. Let me know if there is anything I can improve. I left `participants` as an `any` array because I wasn't sure if there will be contact objects or only IDs.