### PR TITLE
fix: typo in an API method name

### DIFF
--- a/src/api/layers/listener.layer.ts
+++ b/src/api/layers/listener.layer.ts
@@ -28,6 +28,7 @@ import {
   ParticipantEvent,
   PresenceEvent,
   Wid,
+  IncomingCall,
 } from '../model';
 import { MessageType, SocketState, SocketStream } from '../model/enum';
 import { InterfaceMode } from '../model/enum/interface-mode';
@@ -501,18 +502,16 @@ export class ListenerLayer extends ProfileLayer {
   }
 
   /**
-   * @event Escuta por ligações recebidas, seja de áudio ou vídeo.
-   *
-   * Para recusar a ligação, basta chamar o `rejectCall` {@link rejectCall}
-   *
-   * @returns Objeto descartável para parar de ouvir
+   * @event Listen for incoming calls, whether audio or video (pending a reaction).
+   * To reject the call, simply call `rejectCall` {@link rejectCall}
+   * @returns Disposable object to stop listening
    */
-  public onIncomingCall(callback: (call: any) => any) {
+  public onIncomingCall(callback: (call: IncomingCall) => any) {
     return this.registerEvent('onIncomingCall', callback);
   }
 
   /**
-   * Listens to presence changed, by default, it will triggered for active chats only or contacts subscribed (see {@link subscribePresence})
+   * Listens to presence changed, by default, it will be triggered for active chats only or contacts subscribed (see {@link subscribePresence})
    * @event Listens to presence changed
    * @param callback Callback of on presence changed
    * @returns Disposable object to stop the listening

--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -1082,7 +1082,7 @@ export class SenderLayer extends ListenerLayer {
   }
 
   /**
-   * Sets a audio or image view once. Marks message as played
+   * Sets an audio or image view once. Marks message as played
    * @category Chat
    * @param msgId Message id: xxxxx@us.c
    */
@@ -1107,7 +1107,7 @@ export class SenderLayer extends ListenerLayer {
    * ```
    * @category Chat
    * @param to Chat Id
-   * @param duration Duration um miliseconds
+   * @param duration Duration um milliseconds
    */
   public async startTyping(to: string, duration?: number) {
     return evaluateAndReturn(
@@ -1135,7 +1135,7 @@ export class SenderLayer extends ListenerLayer {
    * Starts recording ('Recording...' state)
    * @example
    * ```javascript
-   * // Keep sending recording state, use stopRecoring to finish
+   * // Keep sending recording state, use `stopRecording` to finish
    * await client.startRecording('[number]@c.us');
    *
    * // Keep sending typing state for 5 seconds
@@ -1143,7 +1143,7 @@ export class SenderLayer extends ListenerLayer {
    * ```
    * @category Chat
    * @param to Chat Id
-   * @param duration Duration um miliseconds
+   * @param duration Duration um milliseconds
    */
   public async startRecording(to: string, duration?: number) {
     return evaluateAndReturn(
@@ -1161,7 +1161,7 @@ export class SenderLayer extends ListenerLayer {
    * @category Chat
    * @param to Chat Id
    */
-  public async stopRecoring(to: string) {
+  public async stopRecording(to: string) {
     return evaluateAndReturn(this.page, ({ to }) => WPP.chat.markIsPaused(to), {
       to,
     });
@@ -1346,7 +1346,7 @@ export class SenderLayer extends ListenerLayer {
    * ```
    * @category Chat
    * @param to Chat Id
-   * @param duration Duration um miliseconds
+   * @param duration Duration um milliseconds
    */
   public async sendReactionToMessage(msgId: string, reaction: string | false) {
     return evaluateAndReturn(
@@ -1360,12 +1360,12 @@ export class SenderLayer extends ListenerLayer {
   }
 
   /**
-   * Send a order message
+   * Send an order message
    * To send (prices, tax, shipping or discount), for example: USD 12.90, send them without dots or commas, like: 12900
    *
    * @example
    * ```javascript
-   * // Send Order with a product
+   * // Send an order with a product
    * client.sendOrderMessage('[number]@c.us', [
    *   { type: 'product', id: '67689897878', qnt: 2 },
    *   { type: 'product', id: '37878774457', qnt: 1 },

--- a/src/api/model/incoming-call.ts
+++ b/src/api/model/incoming-call.ts
@@ -1,0 +1,34 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export interface IncomingCall {
+  /** alphanumeric ID of the call, can e.g. usable for hanging up */
+  id: string,
+  /** ID of the caller, can be used to message them directly */
+  peerJid: string,
+  /** Epoch timestamp (seconds) */
+  offerTime: number,
+  isVideo: boolean,
+  isGroup: boolean,
+  groupJid: string | null,
+  canHandleLocally: boolean,
+  outgoing: boolean,
+  isSilenced: boolean,
+  offerReceivedWhileOffline: boolean,
+  webClientShouldHandle: boolean,
+  participants: any[]
+}

--- a/src/api/model/index.ts
+++ b/src/api/model/index.ts
@@ -28,6 +28,7 @@ export { LiveLocation } from './live-location';
 export { ContactStatus } from './contact-status';
 export { GroupCreation } from './group-creation';
 export { WhatsappProfile } from './whatsapp-profile';
+export { IncomingCall } from '.incoming-call';
 export * from './result';
 export * from './get-messages-param';
 export * from './initializer';


### PR DESCRIPTION
**Still WIP**

This change might make a lot of code incompatible, so maybe it is better to save this for the next major release?

Before merging; I think I found one more potential typo:
https://github.com/gekkedev/wppconnect/blob/76baaca6fcb824b26f94a12339c3fda0ef7d5129/src/api/layers/sender.layer.ts#L145
Should be `"error"` in my opinion, but: Is this key from the platform or is it created by WPPC?