### PR TITLE
fix: added missing properties to the Message type definition

### DIFF
--- a/src/api/model/message.ts
+++ b/src/api/model/message.ts
@@ -15,6 +15,7 @@
  * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Wid } from './wid';
 import { Chat } from './chat';
 import { Contact } from './contact';
 import { MessageType } from './enum';
@@ -30,6 +31,7 @@ export interface Message {
    */
   subtype: string;
   t: number;
+  /** profile alias chosen by the sender */
   notifyName: string;
   from: string;
   to: string;
@@ -39,6 +41,7 @@ export interface Message {
   invis: boolean;
   isNewMsg: boolean;
   star: boolean;
+  kicNotified: boolean;
   recvFresh: boolean;
   interactiveAnnotations: any[];
   clientUrl: string;
@@ -53,9 +56,39 @@ export interface Message {
   width: number;
   height: number;
   broadcast: boolean;
-  mentionedJidList: any[];
+  /** array of the users who were mentioned in this message; given in the serialized format: "xxxxxxxxxx@c.us" / "xxxxxxxxxx@g.us" */
+  mentionedJidList: string[];
+  isVcardOverMmsDocument: boolean;
+  /** exists when `type` is set to {@link MessageType.VCARD}; it is the name of the sent contact */
+  vcardFormattedName?: string;
   isForwarded: boolean;
-  labels: any[];
+  hasReaction: boolean;
+  productHeaderImageRejected: boolean;
+  lastPlaybackProgress: number;
+  isDynamicReplyButtonsMsg: boolean;
+  isCarouselCard: boolean;
+  parentMsgId: any; //TODO: specify the type, `null` spotted often
+  isMdHistoryMsg: boolean;
+  stickerSentTs: number;
+  isAvatar: boolean;
+  lastUpdateFromServerTs: number;
+  invokedBotWid: null | Wid;
+  bizBotType: null; //TODO: amend this type definition
+  botResponseTargetId: null; //TODO: amend this type definition
+  botPluginType: null; //TODO: amend this type definition
+  botPluginReferenceIndex: null; //TODO: amend this type definition
+  botPluginSearchProvider: null; //TODO: amend this type definition
+  botPluginSearchUrl: null; //TODO: amend this type definition
+  botPluginSearchQuery: null; //TODO: amend this type definition
+  botPluginMaybeParent: boolean;
+  botReelPluginThumbnailCdnUrl: null; //TODO: amend this type definition
+  botMsgBodyType: null; //TODO: amend this type definition
+  requiresDirectConnection: null; //TODO: amend this type definition
+  bizContentPlaceholderType: null; //TODO: amend this type definition
+  hostedBizEncStateMismatch: boolean;
+  senderOrRecipientAccountTypeHosted: boolean;
+  placeholderCreatedWhenAccountIsHosted: boolean;
+  labels?: any[];
   sender: Contact;
   timestamp: number;
   content: string;
@@ -69,7 +102,9 @@ export interface Message {
    */
   chat: Chat;
   lastSeen: null | number | boolean;
-  chatId: string;
+  /** if `string`, it is serialized: `"user@server"` */
+  chatId: string | Wid;
+  fromMe: boolean;
   /**
    * @deprecated Use the `quotedMsgId` attribute in `getMessageById` to get the message details
    */
@@ -77,6 +112,8 @@ export interface Message {
   quotedMsgId: null;
   mediaData: MediaData;
   recipients?: string[];
+  /** exists for image and video types {@link GroupNotificationType} */
+  caption?: string;
 }
 
 export interface MediaData {


### PR DESCRIPTION
Where I saw `null`, I assumed there could be other values so I added comments as a reminder to specify this later.
I have not seen `labels` in any messages, maybe it is already gone instead of just deprecated, so I marked it as optional.