### PR TITLE
fix: ID type definition of Contact model

### DIFF
--- a/src/api/model/contact.ts
+++ b/src/api/model/contact.ts
@@ -15,7 +15,6 @@
  * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Wid } from './wid';
 import { ProfilePicThumbObj } from './profile-pic-thumb';
 
 /**
@@ -23,7 +22,7 @@ import { ProfilePicThumbObj } from './profile-pic-thumb';
  */
 export interface Contact {
   formattedName: string;
-  id: Wid;
+  id: string;
   isBusiness: boolean;
   isEnterprise: boolean;
   isHighLevelVerified: any;


### PR DESCRIPTION
From what I observed, this is a string (serialized format, user@server). If there are exceptions where it is actually a `WID` object, let me know and I'll adapt this PR.