### PR TITLE
feat: added a profile name getter method

### DIFF
--- a/src/api/layers/profile.layer.ts
+++ b/src/api/layers/profile.layer.ts
@@ -158,6 +158,15 @@ export class ProfileLayer extends StatusLayer {
     );
   }
   /**
+   * Gets the current user profile name
+   * @category Profile
+   */
+  public getProfileName() {
+    return evaluateAndReturn(this.page, () =>
+      WPP.profile.getMyProfileName()
+    );
+  }
+  /**
    * Remove your profile picture
    * @category Profile
    */

--- a/src/api/layers/profile.layer.ts
+++ b/src/api/layers/profile.layer.ts
@@ -162,9 +162,7 @@ export class ProfileLayer extends StatusLayer {
    * @category Profile
    */
   public getProfileName() {
-    return evaluateAndReturn(this.page, () =>
-      WPP.profile.getMyProfileName()
-    );
+    return evaluateAndReturn(this.page, () => WPP.profile.getMyProfileName());
   }
   /**
    * Remove your profile picture


### PR DESCRIPTION
I tested it in the browser only:
![image](https://github.com/user-attachments/assets/abf0ce4f-2ad0-4771-8c4f-5d85fed96ee3)

```js
WPP.profile.setMyProfileName("something")
Promise {<pending>}
WPP.profile.getMyProfileName()
'something'
```

It should not need to be a promise apparently