### PR TITLE
fix: getActiveChat is not async

### DIFF
--- a/src/api/layers/ui.layer.ts
+++ b/src/api/layers/ui.layer.ts
@@ -64,10 +64,10 @@ export class UILayer extends GroupLayer {
   }
 
   /**
-   * Return the current active chat
+   * Return the currently active chat (visually open)
    * @category UI
    */
-  public async getActiveChat() {
+  public getActiveChat() {
     return evaluateAndReturn(this.page, () => WPP.chat.getActiveChat());
   }
 }


### PR DESCRIPTION
Base layer for comparison: https://github.com/wppconnect-team/wa-js/blob/4df7fee17ed071b461e2da28d8e6c9e7592c9739/src/chat/functions/getActiveChat.ts#L33 (it's not `async` there)

Tested in the browser, there is no difference:
![image](https://github.com/user-attachments/assets/f8b0c54f-6b96-47e8-88c9-0a0a3fced090)


It's surely difficult to keep both layers (wa-js/wppconnect) in sync. Have you considered consolidating them into one repo?