### PR TITLE
fix: parent group Id missing in group metadata

### DIFF
--- a/src/api/model/group-metadata.ts
+++ b/src/api/model/group-metadata.ts
@@ -47,6 +47,8 @@ export interface GroupMetadata {
   isLidAddressingMode: boolean;
   isParentGroup: boolean;
   isParentGroupClosed: boolean;
+  /** serialized chat ID of the parent group (community) */
+  parentGroup: string | undefined;
   defaultSubgroup: boolean;
   generalSubgroup: boolean;
   generalChatAutoAddDisabled: boolean;


### PR DESCRIPTION
When there is no parent group, it contains `undefined`:

![image](https://github.com/user-attachments/assets/3b41e794-1e77-4c7c-9fff-2e2caaf3e2fb)
