### PR TITLE
fix: add 'isViewOnce' in message interface

### DIFF
--- a/src/api/model/message.ts
+++ b/src/api/model/message.ts
@@ -55,6 +55,8 @@ export interface Message {
   mediaKeyTimestamp: number;
   width: number;
   height: number;
+  /** exists when `type` is set to {@link MessageType.VIDEO} || {@link MessageType.IMAGE} */
+  isViewOnce?: boolean;
   broadcast: boolean;
   /** array of the users who were mentioned in this message; given in the serialized format: "xxxxxxxxxx@c.us" / "xxxxxxxxxx@g.us" */
   mentionedJidList: string[];


### PR DESCRIPTION
### Description:

This pull request resolves the issue where the `isViewOnce` field was missing in the `Message` type definition, although it was present in the message's JSON response. The field is now correctly included in the type, allowing for proper handling of media files (video, image, or audio) where `isViewOnce` is expected.

When the file is not a media type, the `isViewOnce` field remains undefined, as intended.

### Related Issue:

Closes #2358 