### PR TITLE
fix: added missing group chat properties

### DIFF
--- a/src/api/layers/group.layer.ts
+++ b/src/api/layers/group.layer.ts
@@ -62,7 +62,8 @@ export class GroupLayer extends RetrieverLayer {
   }
 
   /**
-   * Returns group members [Contact] objects
+   * Returns current group members as [Contact] objects
+   * For previous members, see `groupMetadata.pastParticipants`.
    * @category Group
    * @param groupId
    */

--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -51,5 +51,5 @@ export interface Chat {
   hasChatBeenOpened: boolean;
   restricted: boolean;
   /** if you can send messages into the chat without having to be an admin (refers to group chats, see the `isGroup` attribute) */
-  hasOpened boolean;
+  hasOpened: boolean;
 }

--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -47,4 +47,9 @@ export interface Chat {
   contact: Contact;
   groupMetadata: GroupMetadata;
   presence: Presence;
+  /** whether the chat is visually open in WhatsApp Web (see `UILayer.openChat()`) */
+  hasChatBeenOpened: boolean;
+  restricted: boolean;
+  /** if you can send messages into the chat without having to be an admin (refers to group chats, see the `isGroup` attribute) */
+  hasOpened boolean;
 }

--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -30,6 +30,7 @@ export interface Chat {
   archive: boolean;
   muteExpiration: number;
   name: string;
+  /** Whatsapp provides us with built-in spam detection and this is its indicator */
   notSpam: boolean;
   pin: number;
   msgs: null;

--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -36,6 +36,7 @@ export interface Chat {
   kind: string;
   isAnnounceGrpRestrict: boolean;
   ephemeralDuration: number;
+  /** whether the chat is visually open in WhatsApp Web (see `UILayer.openChat()`) */
   hasChatBeenOpened: boolean;
   unreadMentionCount: number;
   hasUnreadMention: boolean;
@@ -47,8 +48,6 @@ export interface Chat {
   contact: Contact;
   groupMetadata: GroupMetadata;
   presence: Presence;
-  /** whether the chat is visually open in WhatsApp Web (see `UILayer.openChat()`) */
-  hasChatBeenOpened: boolean;
   restricted: boolean;
   /** if you can send messages into the chat without having to be an admin (refers to group chats, see the `isGroup` attribute) */
   hasOpened: boolean;

--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -27,6 +27,7 @@ export interface Chat {
   lastReceivedKey: MessageId;
   t: number;
   unreadCount: number;
+  /** whether the message was archived */
   archive: boolean;
   muteExpiration: number;
   name: string;

--- a/src/api/model/group-metadata.ts
+++ b/src/api/model/group-metadata.ts
@@ -59,19 +59,19 @@ export interface GroupMetadata {
   displayCadminPromotion: boolean;
   /** Current members of the group. See `pastParticipants` for former members. */
   participants: {
-    id: Wid,
-    isAdmin: boolean,
-    isSuperAdmin: boolean
+    id: Wid;
+    isAdmin: boolean;
+    isSuperAdmin: boolean;
   }[];
   /** members who applied for membership but still need admin approval */
   pendingParticipants: any[];
   /** former members who left the group or were kicked out */
   pastParticipants: {
-    id: Wid,
+    id: Wid;
     /** UNIX timestamp in seconds of when the leaving occurred */
-    leaveTs: number,
+    leaveTs: number;
     /** was leaving volumtary ('"Left"') or forceful (`"Removed"`) */
-    leaveReason: "Left" | "Removed"
+    leaveReason: "Left" | "Removed";
   }[];
   membershipApprovalRequests: any[];
   subgroupSuggestions: any[];

--- a/src/api/model/group-metadata.ts
+++ b/src/api/model/group-metadata.ts
@@ -70,8 +70,8 @@ export interface GroupMetadata {
     id: Wid;
     /** UNIX timestamp in seconds of when the leaving occurred */
     leaveTs: number;
-    /** was leaving volumtary ('"Left"') or forceful (`"Removed"`) */
-    leaveReason: "Left" | "Removed";
+    /** was leaving volumtary (`"Left"`) or forceful (`"Removed"`) */
+    leaveReason: 'Left' | 'Removed';
   }[];
   membershipApprovalRequests: any[];
   subgroupSuggestions: any[];

--- a/src/api/model/group-metadata.ts
+++ b/src/api/model/group-metadata.ts
@@ -57,11 +57,22 @@ export interface GroupMetadata {
   incognito: boolean;
   hasCapi: boolean;
   displayCadminPromotion: boolean;
-  participants: any[];
+  /** Current members of the group. See `pastParticipants` for former members. */
+  participants: {
+    id: Wid,
+    isAdmin: boolean,
+    isSuperAdmin: boolean
+  }[];
   /** members who applied for membership but still need admin approval */
   pendingParticipants: any[];
   /** former members who left the group or were kicked out */
-  pastParticipants: any[];
+  pastParticipants: {
+    id: Wid,
+    /** UNIX timestamp in seconds of when the leaving occurred */
+    leaveTs: number,
+    /** was leaving volumtary ('"Left"') or forceful (`"Removed"`) */
+    leaveReason: "Left" | "Removed"
+  }[];
   membershipApprovalRequests: any[];
   subgroupSuggestions: any[];
 }

--- a/src/api/model/group-metadata.ts
+++ b/src/api/model/group-metadata.ts
@@ -32,6 +32,7 @@ export interface GroupMetadata {
   descTime: number;
   descOwner: Wid;
   restrict: boolean;
+  /** whether it is an announcement channel of a community */
   announce: boolean;
   noFrequentlyForwarded: boolean;
   ephemeralDuration: number;


### PR DESCRIPTION
They might be optional for other types of chats as I spotted them on the chat objects of groups.