### PR TITLE
fix: reaction method supports message objects

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -1381,20 +1381,20 @@ export class SenderLayer extends ListenerLayer {
   }
 
   /**
-   * Send reaction to message
+   * Send reaction to a message
    * @example
    * ```javascript
-   * // For send Reaction, just to send emoji
-   * await client.sendReactionToMessage('[number]@c.us', '🤯');
+   * // to send an emoji reaction
+   * await client.sendReactionToMessage('true_<number>@c.us_messageId', '🤯');
    *
-   * // to remove reacition
-   * await client.startRecording('[number]@c.us', false);
+   * // to remove a reaction
+   * await client.sendReactionToMessage('true_<number>@c.us_messageId', false);
    * ```
    * @category Chat
-   * @param to Chat Id
-   * @param duration Duration um miliseconds
+   * @param msgId Message Id or `Message` object
+   * @param reaction Emoji as string or `false` to remove an existing reaction
    */
-  public async sendReactionToMessage(msgId: string, reaction: string | false) {
+  public async sendReactionToMessage(msgId: string | Message, reaction: string | false) {
     return evaluateAndReturn(
       this.page,
       ({ msgId, reaction }) => WPP.chat.sendReactionToMessage(msgId, reaction),


### PR DESCRIPTION
the method supports Message objects as input; see: 
https://github.com/wppconnect-team/wa-js/blob/87953a33e8a162ef33474045593960829ac47c3c/src/chat/functions/sendReactionToMessage.ts#L39