### PR TITLE
feat: new notification subtype (group creation)

### DIFF
--- a/src/api/model/enum/group-notification-type.ts
+++ b/src/api/model/enum/group-notification-type.ts
@@ -25,4 +25,5 @@ export enum GroupNotificationType {
   Picture = 'picture',
   Announce = 'announce',
   Restrict = 'restrict',
+  Create = 'create',
 }


### PR DESCRIPTION
I received this new GP2 event subtype shortly/immediately after joining a group though an invitation link, so I suspect it does not actually refer to the group's initial creation:
```
{
  id: 'false_[REDACTED]-1570181234@g.us_[REDACTED]create_[REDACTED]',
  viewed: false,
  body: 'Lorem ipsum',
  type: 'gp2',
  subtype: 'create',
  t: 1570181234,
  from: '[REDACTED]-1570181234@g.us',
  isNewMsg: true,
  star: false,
  kicNotified: false,
  recvFresh: true,
  isFromTemplate: false,
  pollInvalidated: false,
  isSentCagPollCreation: false,
  latestEditMsgKey: null,
  latestEditSenderTimestampMs: null,
  recipients: [],
  mentionedJidList: [],
  groupMentions: [],
  isEventCanceled: false,
  eventInvalidated: false,
  isVcardOverMmsDocument: false,
  isForwarded: false,
  hasReaction: false,
  productHeaderImageRejected: false,
  lastPlaybackProgress: 0,
  isDynamicReplyButtonsMsg: false,
  isCarouselCard: false,
  parentMsgId: null,
  isMdHistoryMsg: false,
  stickerSentTs: 0,
  isAvatar: false,
  lastUpdateFromServerTs: 0,
  invokedBotWid: null,
  bizBotType: null,
  botResponseTargetId: null,
  botPluginType: null,
  botPluginReferenceIndex: null,
  botPluginSearchProvider: null,
  botPluginSearchUrl: null,
  botPluginSearchQuery: null,
  botPluginMaybeParent: false,
  botReelPluginThumbnailCdnUrl: null,
  botMsgBodyType: null,
  requiresDirectConnection: null,
  bizContentPlaceholderType: null,
  hostedBizEncStateMismatch: false,
  senderOrRecipientAccountTypeHosted: false,
  placeholderCreatedWhenAccountIsHosted: false,
  chatId: '[REDACTED]-1570181234@g.us',
  fromMe: false,
  sender: null,
  timestamp: 1570181234,
  content: 'Lorem ipsum',
  isGroupMsg: true,
  mediaData: {}
}
```