### PR TITLE
fix: chat opening methods accept a Wid param

### DIFF
--- a/src/api/layers/ui.layer.ts
+++ b/src/api/layers/ui.layer.ts
@@ -18,6 +18,7 @@
 import { Page } from 'puppeteer';
 import { CreateConfig } from '../../config/create-config';
 import { evaluateAndReturn } from '../helpers';
+import { Wid } from '../model';
 import { GroupLayer } from './group.layer';
 
 export class UILayer extends GroupLayer {
@@ -31,7 +32,7 @@ export class UILayer extends GroupLayer {
    * @category UI
    * @param chatId
    */
-  public async openChat(chatId: string) {
+  public async openChat(chatId: string | Wid) {
     return evaluateAndReturn(
       this.page,
       (chatId: string) => WPP.chat.openChatBottom(chatId),
@@ -45,7 +46,7 @@ export class UILayer extends GroupLayer {
    * @param chatId Chat id
    * @param messageId Message id (For example: '06D3AB3D0EEB9D077A3F9A3EFF4DD030')
    */
-  public async openChatAt(chatId: string, messageId: string) {
+  public async openChatAt(chatId: string | Wid, messageId: string) {
     return evaluateAndReturn(
       this.page,
       (chatId: string, messageId) => WPP.chat.openChatAt(chatId, messageId),

--- a/src/api/layers/ui.layer.ts
+++ b/src/api/layers/ui.layer.ts
@@ -18,7 +18,7 @@
 import { Page } from 'puppeteer';
 import { CreateConfig } from '../../config/create-config';
 import { evaluateAndReturn } from '../helpers';
-import { Wid } from '../model';
+import { Wid, Chat } from '../model';
 import { GroupLayer } from './group.layer';
 
 export class UILayer extends GroupLayer {
@@ -68,7 +68,7 @@ export class UILayer extends GroupLayer {
    * Return the currently active chat (visually open)
    * @category UI
    */
-  public getActiveChat() {
+  public getActiveChat(): Chat {
     return evaluateAndReturn(this.page, () => WPP.chat.getActiveChat());
   }
 }


### PR DESCRIPTION
These 2 methods appear to support `Wid` as input param. References from wa-js:
- https://github.com/wppconnect-team/wa-js/blob/87953a33e8a162ef33474045593960829ac47c3c/src/chat/functions/openChatBottom.ts#L30
- https://github.com/wppconnect-team/wa-js/blob/87953a33e8a162ef33474045593960829ac47c3c/src/chat/functions/openChatAt.ts#L33

Additional change: The return type of `getActiveChat()` appears to be:
```ts
Promise<import("@wppconnect/wa-js/dist/whatsapp").ChatModel>
```
but VSCode and `tsc` disagree with me (not knowing the type (imported by and imported library from a different library, maybe that's why):
```bash
error TS2740: Type 'Promise<any>' is missing the following properties from type 'Chat': id, pendingMsgs, lastReceivedKey, t, and 23 more.
```
Feel free to revert 9c30eec8e8ffac8e06c46e3dc028dbc64f5cfafb if there is a better solution (i.e. if fixing it on wa-js side is possible).