### PR TITLE
fix: notSpam attribute of Chat is optional

### DIFF
--- a/src/api/model/chat.ts
+++ b/src/api/model/chat.ts
@@ -32,7 +32,7 @@ export interface Chat {
   muteExpiration: number;
   name: string;
   /** Whatsapp provides us with built-in spam detection and this is its indicator */
-  notSpam: boolean;
+  notSpam?: boolean;
   pin: number;
   msgs: null;
   kind: string;


### PR DESCRIPTION
I noticed that for **some** chats, this attribute is `undefined`. To reproduce, open some chats and try the following snippets:

indicator that the chat is (still) open:
```js
WPP.chat.getActiveChat()
b {revisionNumber: 36, __x_stale: {…}, __fired: null, __changes: null, __initialized: true, …}
```

to check for presence of the spam detection flag:
```js
WPP.chat.getActiveChat().notSpam
undefined
```

Not sure why WhatsApp does this. ☹️ 