### PR TITLE
fix: ensure 'options' is always defined when sendImage and sendImageFromBase64

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -232,8 +232,8 @@ export class SenderLayer extends ListenerLayer {
       caption,
       quotedMessageId,
       isViewOnce,
-      options.mentionedList,
-      options
+      options?.mentionedList,
+      options || {}
     );
   }
 
@@ -297,6 +297,7 @@ export class SenderLayer extends ListenerLayer {
         quotedMessageId,
         isViewOnce,
         mentionedList,
+        options
       }) => {
         const result = await WPP.chat.sendFileMessage(to, base64, {
           type: 'image',
@@ -324,6 +325,7 @@ export class SenderLayer extends ListenerLayer {
         quotedMessageId,
         isViewOnce,
         mentionedList,
+        options
       }
     );
 
@@ -1475,3 +1477,4 @@ export class SenderLayer extends ListenerLayer {
     return result;
   }
 }
+=


### PR DESCRIPTION
Fixes #2464.

## Changes proposed in this pull request

- Leave mentionedList as optional in sendImage.
- Add 'options' to the missing arguments in sendImageFromBase64.

To test (it takes a while): `npm install github:joelemanoel/wppconnect#patch-1`
