### PR TITLE
fix: Change id in Contact interface from string to object containing

### DIFF
--- a/src/api/model/contact.ts
+++ b/src/api/model/contact.ts
@@ -22,7 +22,11 @@ import { ProfilePicThumbObj } from './profile-pic-thumb';
  */
 export interface Contact {
   formattedName: string;
-  id: string;
+  id: {
+    user: string;
+    server: string;
+    _serialized: string;
+  };
   isBusiness: boolean;
   isEnterprise: boolean;
   isHighLevelVerified: any;


### PR DESCRIPTION
This pull request modifies the `Contact` interface in `src/api/model/contact.ts` to enhance the structure of the `id` property, making it more descriptive and detailed.

Key change:

* [`src/api/model/contact.ts`](diffhunk://#diff-747e91b4e809cdc683885918744fd194f25cfa05f2bc98527dafe88c87aa059bL25-R29): Updated the `id` property of the `Contact` interface from a simple `string` to an object containing `user`, `server`, and `_serialized` fields. This change provides a more structured representation of the contact ID.