### PR TITLE
Fix: isPtt

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -529,7 +529,15 @@ export class SenderLayer extends ListenerLayer {
   ) {
     const result = await evaluateAndReturn(
       this.page,
-      async ({ to, base64, filename, caption, quotedMessageId, messageId }) => {
+      async ({
+        to,
+        base64,
+        filename,
+        caption,
+        quotedMessageId,
+        messageId,
+        isPtt,
+      }) => {
         const result = await WPP.chat.sendFileMessage(to, base64, {
           type: 'audio',
           isPtt: isPtt,
@@ -546,7 +554,7 @@ export class SenderLayer extends ListenerLayer {
           sendMsgResult: await result.sendMsgResult,
         };
       },
-      { to, base64, filename, caption, quotedMessageId, messageId }
+      { to, base64, filename, caption, quotedMessageId, messageId, isPtt }
     );
 
     return result;


### PR DESCRIPTION
when #2570 was added, we missed that `isPtt` is not being passed to the page context, so it was always being passed to page context as undefined.

## Why we need this:

There is a bug in its implementation. The `isPtt` parameter is not being passed correctly to the browser context, which means it will always be undefined inside the `WPP.chat.sendFileMessage` call, instead of using the default value true  provided.


Fix for:

```sh
ERROR [30/10/2025 20:46:19] (284378): isPtt is not defined
    err: {
      "type": "Error",
      "message": "isPtt is not defined",
      "stack":
          Error: isPtt is not defined
              at /<REDACTED>/evaluate-and-return.js:107:31
              at step (/<REDACTED>/evaluate-and-return.js:49:23)
              at Object.next (/<REDACTED>/evaluate-and-return.js:30:53)
              at fulfilled (/<REDACTED>/evaluate-and-return.js:21:58)
          JS Stack: ReferenceError: isPtt is not defined
              at pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:64:52
              at step (pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:47:27)
              at Object.next (pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:28:57)
              at pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:22:75
              at new Promise (<anonymous>)
              at __awaiter (pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:18:16)
              at pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:56:56
              at pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:82:32
              at new Promise (<anonymous>)
              at anonymous (pptr:evaluate;/<REDACTED>/evaluate-and-return.js:99:56:54:14)
          Function: function (_a) { return __awaiter(_this, [_a], void 0, function (_b) {
                                      var result;
                                      var _c;
                                      var to = _b.to, base64 = _b.base64, filename = _b.filename, caption = _b.caption, quotedMessageId = _b.quotedMessageId, messageId = _b.messageId;
                                      return __generator(this, function (_d) {
                                          switch (_d.label) {
                                              case 0: return [4 /*yield*/, WPP.chat.sendFileMessage(to, base64, {
                                                      type: 'audio',
                                                      isPtt: isPtt,
                                                      filename: filename,
                                                      caption: caption,
                                                      quotedMsg: quotedMessageId,
                                                      waitForAck: true,
                                                      messageId: messageId,
                                                  })];
                                              case 1:
                                                  result = _d.sent();
                                                  _c = {
                                                      ack: result.ack,
                                                      id: result.id
                                                  };
                                                  return [4 /*yield*/, result.sendMsgResult];
                                              case 2: return [2 /*return*/, (_c.sendMsgResult = _d.sent(),
                                                      _c)];
                                          }
                                      });
                                  }); }
    }
```