### PR TITLE
[WA-JS] Bump Version to  3.18.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^v3.18.7",
-    "@wppconnect/wa-version": "^1.5.2434",
+    "@wppconnect/wa-js": "^3.18.8",
+    "@wppconnect/wa-version": "^1.5.2614",
     "atob": "^2.1.2",
     "axios": "^1.13.1",
     "boxen": "^5.1.2",

--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -598,4 +598,14 @@ export class HostLayer {
       value
     );
   }
+  /**
+   * Get WhatsApp build constants
+   * @category Host
+   * @returns Build constants information
+   */
+  public async getBuildConstants() {
+    return await evaluateAndReturn(this.page, () =>
+      WPP.conn.getBuildConstants()
+    );
+  }
 }

--- a/src/api/layers/retriever.layer.ts
+++ b/src/api/layers/retriever.layer.ts
@@ -615,4 +615,25 @@ export class RetrieverLayer extends SenderLayer {
       { wid }
     );
   }
+
+  /**
+   * Get LID/PhoneNumber mapping and Contact information
+   *
+   * @example
+   * ```javascript
+   * const info = await client.getPnLidEntry('[number]@c.us');
+   * const info = await client.getPnLidEntry('[number]@lid');
+   * ```
+   *
+   * @category Contact
+   * @param phoneOrLid Contact ID (phone number or LID)
+   * @returns Promise with lid, phoneNumber and contact information
+   */
+  public async getPnLidEntry(phoneOrLid: string) {
+    return await evaluateAndReturn(
+      this.page,
+      (phoneOrLid) => WPP.contact.getPnLidEntry(phoneOrLid),
+      phoneOrLid
+    );
+  }
 }

--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -16,18 +16,23 @@
  */
 
 import type {
+  AllMessageOptions,
   FileMessageOptions,
+  ForwardMessagesOptions,
   ListMessageOptions,
   LocationMessageOptions,
-  TextMessageOptions,
   PoolMessageOptions,
-  ForwardMessagesOptions,
-  AllMessageOptions,
   SendMessageOptions,
+  TextMessageOptions,
 } from '@wppconnect/wa-js/dist/chat';
+import {
+  OrderItems,
+  OrderMessageOptions,
+} from '@wppconnect/wa-js/dist/chat/functions/sendChargeMessage';
 import * as path from 'path';
 import { Page } from 'puppeteer';
 import { CreateConfig } from '../../config/create-config';
+import { PixParams } from '../../types/WAPI';
 import { convertToMP4GIF } from '../../utils/ffmpeg';
 import {
   base64MimeType,
@@ -40,11 +45,6 @@ import { filenameFromMimeType } from '../helpers/filename-from-mimetype';
 import { Message, Wid } from '../model';
 import { ChatState } from '../model/enum';
 import { ListenerLayer } from './listener.layer';
-import {
-  OrderItems,
-  OrderMessageOptions,
-} from '@wppconnect/wa-js/dist/chat/functions/sendChargeMessage';
-import { PixParams } from '../../types/WAPI';
 
 export class SenderLayer extends ListenerLayer {
   constructor(public page: Page, session?: string, options?: CreateConfig) {
@@ -932,6 +932,7 @@ export class SenderLayer extends ListenerLayer {
 
   /**
    * Forwards array of messages (could be ids or message objects)
+   * @deprecated please use {@link forwardMessagesV2}
    * @category Chat
    * @param to Chat id
    * @param messages Array of messages ids to be forwarded
@@ -948,6 +949,32 @@ export class SenderLayer extends ListenerLayer {
       ({ toChatId, msgId, options }) =>
         WPP.chat.forwardMessage(toChatId, msgId, options),
       { toChatId, msgId, options }
+    );
+  }
+
+  /**
+   * Forwards array of messages (could be ids or message objects)
+   * What is the difference between forwardMessage and forwardMessagesV2?
+   * forwardMessage was used to forward a single message
+   * forwardMessagesV2 is used to forward multiple messages
+   * Also, it fixes how we pass the arguments to the whatsapp original function
+   * From positional args to named args (object)
+   * @category Chat
+   * @param to Chat id
+   * @param messages Array of messages ids to be forwarded
+   * @param options
+   * @returns array of messages ID
+   */
+  public async forwardMessagesV2(
+    toChatId: string,
+    messages: string | string[],
+    options?: ForwardMessagesOptions
+  ): Promise<Array<any>> {
+    return evaluateAndReturn(
+      this.page,
+      ({ toChatId, messages, options }) =>
+        WPP.chat.forwardMessages(toChatId, messages, options),
+      { toChatId, messages, options }
     );
   }
 

--- a/src/api/layers/ui.layer.ts
+++ b/src/api/layers/ui.layer.ts
@@ -34,7 +34,7 @@ export class UILayer extends GroupLayer {
   public async openChat(chatId: string) {
     return evaluateAndReturn(
       this.page,
-      (chatId: string) => WPP.chat.openChatBottom(chatId),
+      (chatId: string) => WPP.chat.openChatBottom(chatId, undefined),
       chatId
     );
   }
@@ -48,7 +48,8 @@ export class UILayer extends GroupLayer {
   public async openChatAt(chatId: string, messageId: string) {
     return evaluateAndReturn(
       this.page,
-      (chatId: string, messageId) => WPP.chat.openChatAt(chatId, messageId),
+      (chatId: string, messageId) =>
+        WPP.chat.openChatAt(chatId, messageId, undefined),
       chatId,
       messageId
     );


### PR DESCRIPTION
# What does?

- Bump version of wa-js and wa-version

#### Exposing new functions

- getPnLidEntry
- getBuildConstants
- forwardMessagesV2

#### Fixing current implementation of openChat

- passes new context for openChatBottom and openChatAt (which is undefined)