### PR TITLE
fix: carregar contato antes de buscar foto de perfil

### DIFF
--- a/src/lib/wapi/serializers/serialize-profilePic.js
+++ b/src/lib/wapi/serializers/serialize-profilePic.js
@@ -20,6 +20,19 @@ export const _profilePicfunc = async (id) => {
   let pic = WPP.whatsapp.ProfilePicThumbStore.get(wid);
 
   if (!pic) {
+    try {
+      // Forçar carregar contato para popular ProfilePicThumbStore
+      if (WPP.contact && typeof WPP.contact.queryExists === 'function') {
+        await WPP.contact.queryExists(id);
+      }
+      // Tentar buscar contato do store
+      if (WPP.contact && typeof WPP.contact.getContact === 'function') {
+        await WPP.contact.getContact(id);
+      }
+    } catch (e) {
+      // Falha silenciosa - continua mesmo se não conseguir carregar
+    }
+
     pic = await WPP.whatsapp.ProfilePicThumbStore.find(wid);
   }
 


### PR DESCRIPTION
## Descrição                                                                                     
                                                                                                   
  Força o carregamento do contato antes de buscar a foto de perfil.                                
                                                                                                   
  ## Problema                                                                                      
  `getProfilePicFromServer()` retorna `eurl: null` para contatos sem chat aberto porque o          
  `ProfilePicThumbStore` não tá populado.                                                          
                                                                                                   
  ## Solução                                                                                       
  Chamar `queryExists()` e `getContact()` antes de buscar a foto. Assim o store fica populado com  
  os dados do contato.                                                                             
                                                                                                   
  ## Fixes                                                                                         
  #1315