### PR TITLE
fix: guard against undefined media in downloadMedia with helpful error messages

### DIFF
--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -95,10 +95,22 @@ export class Whatsapp extends BusinessLayer {
       messageId = messageId.id;
     }
 
+    if (!messageId) {
+      throw new Error(
+        'downloadMedia: messageId is undefined or null. ' +
+          'Make sure the message object (e.g. quotedMsgObj) exists before calling downloadMedia.'
+      );
+    }
+
     return await evaluateAndReturn(
       this.page,
-      async (messageId) =>
-        WPP.util.blobToBase64(await WPP.chat.downloadMedia(messageId)),
+      async (messageId) => {
+        const media = await WPP.chat.downloadMedia(messageId);
+        if (!media) {
+          throw new Error(`downloadMedia: no media found for message id "${messageId}". The message may not contain downloadable media.`);
+        }
+        return WPP.util.blobToBase64(media);
+      },
       messageId
     );
   }


### PR DESCRIPTION
## Summary
Fixes #2736

## Problem
Calling `downloadMedia` with a message id from `quotedMsgObj` when the object is null/undefined caused an unhandled crash deep inside WPP: `Cannot read properties of undefined (reading 'msgChunks')`.

## Fix
- Guard against falsy `messageId` with a clear error message explaining the cause
- Guard against null media blob returned by `WPP.chat.downloadMedia` with a descriptive error
- Both errors now include actionable context for the developer