### PR TITLE
feat: add alpha tag support for npm publish and enable service worker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,12 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Publish in NPM
-        run: npm publish
+        run: |
+          if [[ "${{ github.ref }}" == *"-alpha"* ]]; then
+            npm publish --tag alpha
+          else
+            npm publish
+          fi
 
       - name: Generate Changelog
         id: generate_changelog
@@ -65,7 +70,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.generate_changelog.outputs.changelog }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref, '-alpha') }}
 
       - name: Build API-Docs
         run: npm run docs:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
           - patch
           - minor
           - major
-          - pre*
+          - alpha
         default: 'patch'
 
 jobs:
@@ -51,4 +51,9 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Release
-        run: 'npx release-it --increment ${{ github.event.inputs.increment }}'
+        run: |
+          if [ "${{ github.event.inputs.increment }}" = "alpha" ]; then
+            npx release-it --preRelease=alpha --ci
+          else
+            npx release-it --increment ${{ github.event.inputs.increment }} --ci
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3-alpha.0 (2026-05-07)
+
+### Features
+
+- add alpha tag support for npm publish and release process ([ab7603a](https://github.com/wppconnect-team/wppconnect/commit/ab7603a928211762d69a2bdf8a7fb5cbfd94ac58))
+
 ## 2.0.2 (2026-05-04)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wppconnect-team/wppconnect",
-  "version": "2.0.2",
+  "version": "2.0.3-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wppconnect-team/wppconnect",
-      "version": "2.0.2",
+      "version": "2.0.3-alpha.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@wppconnect/wa-js": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wppconnect-team/wppconnect",
-  "version": "2.0.2",
+  "version": "2.0.3-alpha.0",
   "description": "WPPConnect is an open source project developed by the JavaScript community with the aim of exporting functions from WhatsApp Web to the node, which can be used to support the creation of any interaction, such as customer service, media sending, intelligence recognition based on phrases artificial and many other things, use your imagination... 😀🤔💭",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -34,29 +34,6 @@ import { LoadingScreenCallback } from '../api/model';
 import { LogLevel } from '../utils/logger';
 import { sleep } from '../utils/sleep';
 
-export async function unregisterServiceWorker(page: Page) {
-  await page.evaluateOnNewDocument(() => {
-    // Remove existent service worker
-    navigator.serviceWorker
-      .getRegistrations()
-      .then((registrations) => {
-        for (let registration of registrations) {
-          registration.unregister();
-        }
-      })
-      .catch((err) => null);
-
-    // Disable service worker registration
-    // @ts-ignore
-    navigator.serviceWorker.register = new Promise(() => {});
-
-    setInterval(() => {
-      window.onerror = console.error;
-      window.onunhandledrejection = console.error;
-    }, 500);
-  });
-}
-
 /**
  * Força o carregamento de uma versão específica do WhatsApp WEB
  * @param page Página a ser injetada
@@ -120,8 +97,6 @@ export async function initWhatsapp(
   }
 
   await page.setUserAgent(useragentOverride);
-
-  await unregisterServiceWorker(page);
 
   if (version) {
     log?.('verbose', `Setting WhatsApp WEB version to ${version}`);


### PR DESCRIPTION
What worker does:

**Full networking stack:** WANoiseSocket + WAFrameSocket — WhatsApp's Noise Protocol WebSocket connection runs here
**E2E crypto:** Curve25519, Ed25519, AES-GCM, HMAC, HKDF, SHA256 — all in-worker
**Offline resume:** WAWebOfflineHandler — batched offline message processing with QPL performance tracking and WAM (analytics) reporting
**Persisted jobs:** WAWebPersistedJobManager — background jobs (key exchanges, prekey fetches, logout) that survive page reloads
**Worker↔UI bridge:** WAWebBackendWorkerBridge / WAWebSWBus — the page is just a UI shell; all state lives here
**Push notifications:** WAWebPushNotificationsOfflineBbApi — full offline notification handling