### PR TITLE
feat: add ListsLayer for personal account chat grouping (WPP.lists)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@wppconnect/wa-js": "^4.2.0",
+        "@wppconnect/wa-js": "^4.3.0",
         "@wppconnect/wa-version": "^1.5.3941",
         "atob": "^2.1.2",
         "axios": "^1.16.1",
@@ -4487,9 +4487,9 @@
       }
     },
     "node_modules/@wppconnect/wa-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.2.0.tgz",
-      "integrity": "sha512-VMylnmgXbMmmFBRY/s8E29cCOd0UEpAqmJnOvdtiNhQnXceg1B+4Wj0UCgQJ4QRdP8cDBr7syT7ioi1Z17dgSQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.3.0.tgz",
+      "integrity": "sha512-XZ8BXjOMXizpPWV/LaKwCoJsBdwrUH6Eb1GXj40iclI/bUkGarB9aJ9QYnvkTkrB3eFHmrowSjJFQwhZch3ZmA==",
       "license": "Apache-2.0",
       "engines": {
         "whatsapp-web": ">=2.2326.10-beta"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@commitlint/config-conventional": "^20.5.3",
     "@commitlint/cz-commitlint": "^20.5.3",
     "@eslint/js": "^10.0.1",
+    "@tony.ganchev/eslint-plugin-header": "^3.4.4",
     "@types/atob": "^2.1.4",
     "@types/mime-types": "^3.0.1",
     "@types/mocha": "^10.0.10",
@@ -76,7 +77,6 @@
     "conventional-changelog-cli": "^5.0.0",
     "eslint": "10.3.0",
     "eslint-config-prettier": "^10.1.8",
-    "@tony.ganchev/eslint-plugin-header": "^3.4.4",
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
@@ -94,7 +94,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.2.0",
+    "@wppconnect/wa-js": "^4.3.0",
     "@wppconnect/wa-version": "^1.5.3941",
     "atob": "^2.1.2",
     "axios": "^1.16.1",

--- a/src/api/layers/labels.layer.ts
+++ b/src/api/layers/labels.layer.ts
@@ -18,9 +18,9 @@
 import { Page } from 'puppeteer';
 import { CreateConfig } from '../../config/create-config';
 import { evaluateAndReturn } from '../helpers';
-import { CatalogLayer } from './catalog.layer';
+import { ListsLayer } from './lists.layer';
 
-export class LabelsLayer extends CatalogLayer {
+export class LabelsLayer extends ListsLayer {
   constructor(public page: Page, session?: string, options?: CreateConfig) {
     super(page, session, options);
   }

--- a/src/api/layers/lists.layer.ts
+++ b/src/api/layers/lists.layer.ts
@@ -1,0 +1,142 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Page } from 'puppeteer';
+import { CreateConfig } from '../../config/create-config';
+import { evaluateAndReturn } from '../helpers';
+import { CatalogLayer } from './catalog.layer';
+
+export class ListsLayer extends CatalogLayer {
+  constructor(public page: Page, session?: string, options?: CreateConfig) {
+    super(page, session, options);
+  }
+
+  /**
+   * Create a new list and optionally add chats to it.
+   * Works for both personal and business accounts.
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * const id = await client.createList('Family', ['number@c.us', 'number2@c.us']);
+   * console.log(id); // '42'
+   * ```
+   * @param name List name
+   * @param chatIds Chat IDs to add to the list
+   * @param colorIndex Optional color index
+   */
+  public async createList(
+    name: string,
+    chatIds: string[] = [],
+    colorIndex?: number
+  ) {
+    return await evaluateAndReturn(
+      this.page,
+      ({ name, chatIds, colorIndex }) =>
+        WPP.lists.create(name, chatIds, colorIndex),
+      { name, chatIds, colorIndex }
+    );
+  }
+
+  /**
+   * Return all custom lists
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * const lists = await client.getAllLists();
+   * ```
+   */
+  public async getAllLists() {
+    return await evaluateAndReturn(this.page, () => WPP.lists.list());
+  }
+
+  /**
+   * Add chats to an existing list
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * await client.addChatsToList('42', ['number@c.us', 'number2@c.us']);
+   * ```
+   * @param listId List ID
+   * @param chatIds Chat IDs to add
+   */
+  public async addChatsToList(listId: string, chatIds: string[]) {
+    return await evaluateAndReturn(
+      this.page,
+      ({ listId, chatIds }) => WPP.lists.addChats(listId, chatIds),
+      { listId, chatIds }
+    );
+  }
+
+  /**
+   * Remove chats from a list
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * await client.removeChatsFromList('42', ['number@c.us']);
+   * ```
+   * @param listId List ID
+   * @param chatIds Chat IDs to remove
+   */
+  public async removeChatsFromList(listId: string, chatIds: string[]) {
+    return await evaluateAndReturn(
+      this.page,
+      ({ listId, chatIds }) => WPP.lists.removeChats(listId, chatIds),
+      { listId, chatIds }
+    );
+  }
+
+  /**
+   * Rename a list
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * await client.renameList('42', 'Close Friends');
+   * ```
+   * @param listId List ID
+   * @param newName New name
+   */
+  public async renameList(listId: string, newName: string) {
+    return await evaluateAndReturn(
+      this.page,
+      ({ listId, newName }) => WPP.lists.rename(listId, newName),
+      { listId, newName }
+    );
+  }
+
+  /**
+   * Delete a list
+   * @category Lists
+   *
+   * @example
+   * ```javascript
+   * await client.deleteList('42');
+   * ```
+   * @param listId List ID
+   */
+  public async deleteList(listId: string) {
+    return await evaluateAndReturn(
+      this.page,
+      ({ listId }) => WPP.lists.remove(listId),
+      { listId }
+    );
+  }
+}

--- a/src/tests/05.lists.test.ts
+++ b/src/tests/05.lists.test.ts
@@ -1,0 +1,72 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import * as assert from 'assert';
+import { describeAuthenticatedTest, testUserId } from './common';
+
+describeAuthenticatedTest('Lists functions', function (getClient) {
+  let listId: string;
+
+  before(function () {
+    if (!testUserId) {
+      this.skip();
+    }
+  });
+
+  it('createList — returns a string ID', async function () {
+    const result = await getClient().createList('WPPConnect Test List', []);
+    assert.strictEqual(typeof result, 'string');
+    assert.ok(result.length > 0);
+    listId = result;
+  });
+
+  it('getAllLists — newly created list is present', async function () {
+    const result = await getClient().getAllLists();
+    assert.ok(Array.isArray(result));
+    const found = result.find((l: any) => l.id === listId);
+    assert.ok(found, `List ${listId} not found in getAllLists`);
+    assert.strictEqual(found.name, 'WPPConnect Test List');
+  });
+
+  it('renameList — name is updated', async function () {
+    await getClient().renameList(listId, 'WPPConnect Test List (renamed)');
+    const result = await getClient().getAllLists();
+    const found = result.find((l: any) => l.id === listId);
+    assert.strictEqual(found?.name, 'WPPConnect Test List (renamed)');
+  });
+
+  it('addChatsToList — chat appears in list after add', async function () {
+    if (!testUserId) return this.skip();
+    await getClient().addChatsToList(listId, [testUserId]);
+    const lists = await getClient().getAllLists();
+    const found = lists.find((l: any) => l.id === listId);
+    assert.ok(found, 'list not found after addChatsToList');
+  });
+
+  it('removeChatsFromList — does not throw for valid list', async function () {
+    if (!testUserId) return this.skip();
+    // WPP.lists.removeChats returns void — assert strictEqual undefined
+    const result = await getClient().removeChatsFromList(listId, [testUserId]);
+    assert.strictEqual(result, undefined);
+  });
+
+  it('deleteList — list is gone after deletion', async function () {
+    await getClient().deleteList(listId);
+    const result = await getClient().getAllLists();
+    const still = result.find((l: any) => l.id === listId);
+    assert.strictEqual(still, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ListsLayer` with 6 methods wrapping `WPP.lists`: `createList`, `getAllLists`, `addChatsToList`, `removeChatsFromList`, `renameList`, `deleteList`
- Inserts `ListsLayer` into the class hierarchy between `CatalogLayer` and `LabelsLayer`
- Bumps `@wppconnect/wa-js` to `^4.3.0`, which ships native types for `WPP.lists` — see wppconnect-team/wa-js#3430