### PR TITLE
build(deps): update dependency @wppconnect/wa-js to ^4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@wppconnect/wa-js": "^4.3.1",
+        "@wppconnect/wa-js": "^4.4.0",
         "@wppconnect/wa-version": "^1.5.3941",
         "atob": "^2.1.2",
         "axios": "^1.18.1",
@@ -4394,9 +4394,9 @@
       }
     },
     "node_modules/@wppconnect/wa-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.3.1.tgz",
-      "integrity": "sha512-h54HvMisVhDk5gXvRZYp8feBJSNZI/V/POP8oMfgMuYz54XPzemvgrzOOsef1svG03KCA8tI/6VzKMUEnqtejA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.4.0.tgz",
+      "integrity": "sha512-2mtOLPeICIjT33MjDnd+gRU+JcwJ+o2cKc/kOxnU4Bdj0mm4e7aArQAKWd0W3DjexDNeBwce9Cz1sb/7dqxQKQ==",
       "license": "Apache-2.0",
       "engines": {
         "whatsapp-web": ">=2.2326.10-beta"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.3.1",
+    "@wppconnect/wa-js": "^4.4.0",
     "@wppconnect/wa-version": "^1.5.3941",
     "atob": "^2.1.2",
     "axios": "^1.18.1",


### PR DESCRIPTION
Updates `@wppconnect/wa-js` from `^4.3.1` to `^4.4.0`.

## Why

wa-js 4.4.0 includes fixes for recent WhatsApp Web versions, notably:

- **fix: restore `MsgKey._serialized` on WhatsApp Web >= 2.3000.1042401057** (wppconnect-team/wa-js#3484) — event payloads (`ack`, `sendMessage`, etc.) were delivering message ids **without `_serialized`** (a minified `$1` property appeared instead), breaking consumers that rely on `id._serialized`:
  ```js
  {
    fromMe: true,
    remote: '000000000000@lid',
    id: '3EB0451E2087F6900000000',
    '$1': 'true_000000000000@lid_3EB0451E2087F6900000000'
  }
  ```
- fix(loader): recover from stale negative module lookups (wppconnect-team/wa-js#3476)
- fix: restore module bindings broken on WhatsApp Web 2.3000.1042652105 (wppconnect-team/wa-js#3480)
- Feat: WhatsApp VoIP calls (wppconnect-team/wa-js#3477)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7Vyt1fg6xatRWKQL7x7ut