### PR TITLE
build(deps): update dependency @wppconnect/wa-js to ^4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.2",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@wppconnect/wa-js": "^4.4.0",
+        "@wppconnect/wa-js": "^4.4.1",
         "@wppconnect/wa-version": "^1.5.3941",
         "atob": "^2.1.2",
         "axios": "^1.18.1",
@@ -4394,9 +4394,9 @@
       }
     },
     "node_modules/@wppconnect/wa-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.4.0.tgz",
-      "integrity": "sha512-2mtOLPeICIjT33MjDnd+gRU+JcwJ+o2cKc/kOxnU4Bdj0mm4e7aArQAKWd0W3DjexDNeBwce9Cz1sb/7dqxQKQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.4.1.tgz",
+      "integrity": "sha512-4w/ufvnnwN5rB4wVl366sSKoveukQn5F2f0IYutPQ1WFbhXc9oLwmmCiajAjKxvdWK+SR3xxpwvvN5+8xI6YRA==",
       "license": "Apache-2.0",
       "engines": {
         "whatsapp-web": ">=2.2326.10-beta"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.4.0",
+    "@wppconnect/wa-js": "^4.4.1",
     "@wppconnect/wa-version": "^1.5.3941",
     "atob": "^2.1.2",
     "axios": "^1.18.1",


### PR DESCRIPTION
Updates `@wppconnect/wa-js` from `^4.4.0` to `^4.4.1`.

## Release Notes

[wppconnect-team/wa-js v4.4.1](https://github.com/wppconnect-team/wa-js/releases/tag/v4.4.1)

- fix: restore `MsgKey._serialized` on keys created before injection ([#3488](https://github.com/wppconnect-team/wa-js/pull/3488))

Message keys created before WA-JS injected (everything already loaded in `MsgStore`, including `chat.lastReceivedKey`) were missing `_serialized` on WhatsApp Web >= 2.3000.1042401057, exposing the minified `$1` property instead — visible in `chat.getMessages` results and in event payloads crossing the puppeteer bridge. wa-js 4.4.1 migrates those keys in place so `_serialized` is always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ekQS773J9zRzNLeGfBJ3