### PR TITLE
 fix: restore msg.id when MsgKey._serialized is null on WhatsApp 2.3000.x

### DIFF
--- a/src/lib/wapi/serializers/serialize-message.js
+++ b/src/lib/wapi/serializers/serialize-message.js
@@ -15,13 +15,21 @@
  * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+// Since WhatsApp Web 2.3000.x, a MsgKey's cached `_serialized` property can come
+// back `null` (its minified name changed), while `MsgKey.toString()` still returns
+// the correct serialized id. Reading `_serialized` directly left `id` undefined,
+// which silently broke quoted replies (`quotedMsg`) and anything else relying on
+// `msg.id`. Prefer `_serialized`, fall back to `toString()`.
+const serializeMsgKey = (key) =>
+  key ? key._serialized || key.toString?.() : undefined;
+
 export const _serializeMessageObj = (obj) => {
   if (obj == undefined) {
     return null;
   }
   if (obj.quotedMsg && obj.quotedMsgObj) obj.quotedMsgObj();
   return Object.assign(window.WAPI._serializeRawObj(obj), {
-    id: obj.id._serialized,
+    id: serializeMsgKey(obj.id),
     from: obj.from._serialized,
     quotedParticipant: obj?.quotedParticipant?._serialized,
     author: obj?.author?._serialized,
@@ -40,7 +48,7 @@ export const _serializeMessageObj = (obj) => {
     isNotification: obj.isNotification,
     isPSA: obj.isPSA,
     type: obj.type,
-    quotedMsgId: obj?._quotedMsgObj?.id?._serialized,
+    quotedMsgId: serializeMsgKey(obj?._quotedMsgObj?.id),
     mediaData: window.WAPI._serializeRawObj(obj['mediaData']),
   });
 };


### PR DESCRIPTION
## Changes proposed in this pull request

Since WhatsApp Web `2.3000.x`, a `MsgKey`'s cached `_serialized` property can come
back `null` (its minified property name changed), while `MsgKey.toString()` still
returns the correct serialized id (e.g. `false_...@lid_ACD2...`).

`_serializeMessageObj` reads `obj.id._serialized` directly, so every serialized
message — including the objects delivered to `onMessage` / `onAnyMessage` — now comes
back with `id === undefined`.

- This silently breaks **quoted replies**: `sendText` / `reply` resolve `quotedMsg`
  from the message id, so with `id` missing the quote is dropped and a plain message
  is sent instead (reproduced in both direct chats and groups).
- It also breaks anything else that relies on `msg.id`.

The fix adds a small `serializeMsgKey` helper that prefers `_serialized` and falls
back to `toString()`, applied to both `id` and `quotedMsgId`.

Verified live against WhatsApp Web `2.3000.1043421788` / WA-JS `3.23.3`: before the
change `msg.id` is `undefined` and replies don't quote; after it, `msg.id` is
populated and replies quote correctly.

To test (it takes a while): `npm install github:TheMihirSensei/wppconnect#fix/serialize-msg-id-null`
---