### PR TITLE
fix(deps): update dependency @wppconnect/wa-version to ^1.5.4472

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@wppconnect/wa-js": "^4.4.3",
-        "@wppconnect/wa-version": "^1.5.3941",
+        "@wppconnect/wa-version": "^1.5.4472",
         "atob": "^2.1.2",
         "axios": "^1.18.1",
         "boxen": "^5.1.2",
@@ -4355,19 +4355,19 @@
       }
     },
     "node_modules/@wppconnect/wa-version": {
-      "version": "1.5.4149",
-      "resolved": "https://registry.npmjs.org/@wppconnect/wa-version/-/wa-version-1.5.4149.tgz",
-      "integrity": "sha512-+WN6cf1QeyDhOv62FA3UfhJmctQ7w6jE7tFQE+fbEB5WCXloPthTyMa8P/nRYEC5AbJLrGRQI/VYXqkVR/2x7w==",
+      "version": "1.5.4472",
+      "resolved": "https://registry.npmjs.org/@wppconnect/wa-version/-/wa-version-1.5.4472.tgz",
+      "integrity": "sha512-ZEMu40mSfN7kBMdWhlJjUNpjXx+pZuNWk3TNV+4Ffct+RgrOuQX/6j6mGeGJZeP53wQ96bG20sAW2eJLgl9JvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "node-fetch": "^2.7.0",
-        "semver": "^7.7.4"
+        "semver": "^7.8.5"
       }
     },
     "node_modules/@wppconnect/wa-version/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@wppconnect/wa-js": "^4.4.3",
-    "@wppconnect/wa-version": "^1.5.3941",
+    "@wppconnect/wa-version": "^1.5.4472",
     "atob": "^2.1.2",
     "axios": "^1.18.1",
     "boxen": "^5.1.2",


### PR DESCRIPTION
Atualiza `@wppconnect/wa-version` de `^1.5.3941` para `^1.5.4472`, mantendo a lista de versões suportadas do WhatsApp Web em dia.

- Última versão conhecida: `2.3000.1039590135-alpha` → `2.3000.1044159214-alpha`
- Transitiva: `semver` `7.8.4` → `7.8.5`

Alterações restritas a `package.json` e `package-lock.json`.