### PR TITLE
fix: resolve conflicting variable initialization

### DIFF
--- a/src/lib/wapi/jssha/index.js
+++ b/src/lib/wapi/jssha/index.js
@@ -620,8 +620,7 @@
     return (a >>> b) | (a << (32 - b));
   }
   function t(e, b) {
-    var d = null,
-      d = new a(e.a, e.b);
+    var d = new a(e.a, e.b);
     return (d =
       32 >= b
         ? new a(


### PR DESCRIPTION
Removes the immediately overwritten jsSHA local initialization reported as a Code Quality reliability error.

Validation: targeted ESLint; WAPI webpack build.