### PR TITLE
fix: resolve reliability control-flow warnings

### DIFF
--- a/src/api/layers/group.layer.ts
+++ b/src/api/layers/group.layer.ts
@@ -193,8 +193,6 @@ export class GroupLayer extends RetrieverLayer {
         WPP.group.promoteParticipants(groupId, participantId),
       { groupId, participantId }
     );
-
-    return true;
   }
 
   /**

--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -423,12 +423,6 @@ export class HostLayer {
       return true;
     }
 
-    if (authenticated === false) {
-      this.tryAutoClose();
-      this.log('warn', 'Not logged');
-      throw new Error('Not logged');
-    }
-
     this.tryAutoClose();
 
     if (this.autoCloseCalled) {

--- a/src/api/whatsapp.ts
+++ b/src/api/whatsapp.ts
@@ -18,6 +18,7 @@
 import axios from 'axios';
 import * as fs from 'fs';
 import { Page } from 'puppeteer';
+import { pipeline } from 'stream/promises';
 import { CreateConfig } from '../config/create-config';
 import { useragentOverride } from '../config/WAuserAgente';
 import { sleep } from '../utils/sleep';
@@ -271,37 +272,13 @@ export class Whatsapp extends BusinessLayer {
         message.size
       );
 
-      inputReadStream.pipe(decryptedStream).pipe(outputWriteStream);
+      await pipeline(inputReadStream, decryptedStream, outputWriteStream);
 
-      await new Promise<void>((resolve, reject) => {
-        outputWriteStream.on('finish', () => {
-          console.log(
-            `Deciphering complete. Deleting the encrypted file: ${tempSavePath}`
-          );
-          fs.unlink(tempSavePath, (error) => {
-            if (error) {
-              console.error(
-                `Error deleting the input file: ${tempSavePath}`,
-                error
-              );
-              reject(error);
-            } else {
-              console.log('Encrypted file deleted successfully');
-              resolve();
-            }
-          });
-        });
-
-        outputWriteStream.on('error', (error) => {
-          console.error(`Error during writing file: ${savePath}`, error);
-          reject(error);
-        });
-
-        decryptedStream.on('error', (error) => {
-          console.error('An error occurred while decrypting the file', error);
-          reject(error);
-        });
-      });
+      console.log(
+        `Deciphering complete. Deleting the encrypted file: ${tempSavePath}`
+      );
+      await fs.promises.unlink(tempSavePath);
+      console.log('Encrypted file deleted successfully');
     } catch (error) {
       throw error;
     }
@@ -319,12 +296,8 @@ export class Whatsapp extends BusinessLayer {
           makeOptions(useragentOverride, 'stream')
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const writer = fs.createWriteStream(outputPath);
-          response.data.pipe(writer);
-          writer.on('finish', resolve);
-          writer.on('error', reject);
-        });
+        const writer = fs.createWriteStream(outputPath);
+        await pipeline(response.data, writer);
 
         console.log(`Encrypted file downloaded at ${outputPath}`);
         return;

--- a/src/lib/wapi/functions/get-unread-messages-in-chat.js
+++ b/src/lib/wapi/functions/get-unread-messages-in-chat.js
@@ -30,11 +30,6 @@ export function getUnreadMessagesInChat(
 
   // look for unread messages, newest is at the end of array
   for (let i = messages.length - 1; i >= 0; i--) {
-    // system message: skip it
-    if (i === 'remove') {
-      continue;
-    }
-
     // get message
     let messageObj = messages[i];
 


### PR DESCRIPTION
## Summary
- propagates errors from both file stream pipelines
- removes unreachable authentication/group branches
- removes an impossible number/string comparison

## Validation
- lint passed
- WAPI and TypeScript builds passed
- local Mocha startup remains blocked by the repository's Node 24 ESM extension-resolution issue