### PR TITLE
chore: clear actionable quality findings

### DIFF
--- a/examples/rest/index.js
+++ b/examples/rest/index.js
@@ -50,7 +50,7 @@ app.post('/sendmessage', async function (req, res) {
   const executa = async () => {
     if (typeof Instancia === 'object') {
       // Validando se a lib está iniciada .... Validating if lib is started
-      status = await Instancia.getConnectionState(); // validadado o estado da conexão com o whats
+      const status = await Instancia.getConnectionState(); // validadado o estado da conexão com o whats
       //whats connection status validated
       if (status === 'CONNECTED') {
         let numeroexiste = await Instancia.checkNumberStatus(
@@ -107,7 +107,7 @@ app.post('/sendpixmessage', async function (req, res) {
   const executa = async () => {
     if (typeof Instancia === 'object') {
       // Validando se a lib está iniciada .... Validating if lib is started
-      status = await Instancia.getConnectionState(); // validadado o estado da conexão com o whats
+      const status = await Instancia.getConnectionState(); // validadado o estado da conexão com o whats
       //whats connection status validated
       if (status === 'CONNECTED') {
         let numeroexiste = await Instancia.checkNumberStatus(

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
         "husky": "^9.1.7",
-        "mocha": "^11.7.6",
+        "mocha": "^11.3.0",
         "prettier": "^2.8.8",
         "pretty-quick": "^4.2.2",
         "regenerator-runtime": "^0.14.1",
@@ -6607,9 +6607,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8634,16 +8634,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -9523,30 +9513,29 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
+      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
+        "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "minimatch": "^5.1.6",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
+        "workerpool": "^6.5.1",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -9598,7 +9587,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/minimatch": {
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
@@ -9612,6 +9601,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -13236,9 +13238,9 @@
       "license": "MIT"
     },
     "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.7.0",
     "husky": "^9.1.7",
-    "mocha": "^11.7.6",
+    "mocha": "^11.3.0",
     "prettier": "^2.8.8",
     "pretty-quick": "^4.2.2",
     "regenerator-runtime": "^0.14.1",

--- a/src/api/layers/business.layer.ts
+++ b/src/api/layers/business.layer.ts
@@ -19,8 +19,6 @@ import { Page } from 'puppeteer';
 import { ControlsLayer } from './controls.layer';
 import { CreateConfig } from '../../config/create-config';
 import { evaluateAndReturn } from '../helpers';
-import { BusinessProfileModel } from '@wppconnect/wa-js/dist/whatsapp';
-import { Chat } from '../model';
 
 export class BusinessLayer extends ControlsLayer {
   constructor(public page: Page, session?: string, options?: CreateConfig) {

--- a/src/api/layers/catalog.layer.ts
+++ b/src/api/layers/catalog.layer.ts
@@ -18,7 +18,6 @@
 import { Page } from 'puppeteer';
 import { CreateConfig } from '../../config/create-config';
 import { evaluateAndReturn } from '../helpers';
-import { HostLayer } from './host.layer';
 import { CommunityLayer } from './community.layer';
 
 export class CatalogLayer extends CommunityLayer {

--- a/src/api/layers/profile.layer.ts
+++ b/src/api/layers/profile.layer.ts
@@ -16,7 +16,6 @@
  */
 
 import { Page } from 'puppeteer';
-import { HostLayer } from './host.layer';
 import {
   base64MimeType,
   fileToBase64,

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -32,7 +32,6 @@ import { Logger } from 'winston';
 import { SessionToken } from '../token-store';
 import { LoadingScreenCallback } from '../api/model';
 import { LogLevel } from '../utils/logger';
-import { sleep } from '../utils/sleep';
 
 export async function unregisterServiceWorker(page: Page) {
   await page.evaluateOnNewDocument(() => {


### PR DESCRIPTION
## Summary
- declare example connection state locally
- remove four unused imports
- move Mocha to the safe 11.3 release line to clear the jsdiff advisory

## Validation
- npm audit: 0 vulnerabilities
- npm run lint
- npm run build
- tests are blocked by an existing QR-code test type error

The remaining Code Quality entries are in the vendored jsSHA implementation and are intentionally not hand-edited.