### PR TITLE
fix: remove unreachable group demotion return

### DIFF
--- a/src/api/layers/group.layer.ts
+++ b/src/api/layers/group.layer.ts
@@ -211,8 +211,6 @@ export class GroupLayer extends RetrieverLayer {
         WPP.group.demoteParticipants(groupId, participantId),
       { groupId, participantId }
     );
-
-    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove the unreachable fallback return after valuateAndReturn`n- preserve the actual result of the group demotion operation

## Validation
- targeted ESLint passes
- full build passes
- npm audit: 0 vulnerabilities