### PR TITLE
fix: bump wa-js version to 4.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.7",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@wppconnect/wa-js": "^4.4.3",
+        "@wppconnect/wa-js": "^4.6.0",
         "@wppconnect/wa-version": "^1.5.4472",
         "atob": "^2.1.2",
         "axios": "^1.18.1",
@@ -4699,12 +4699,12 @@
       }
     },
     "node_modules/@wppconnect/wa-js": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.4.3.tgz",
-      "integrity": "sha512-nyIF/0v3qk7rfir+wFPihr3JL+rVMN3UsaruoG/ToQMZ9EzBVd2lkK+aIyvg2iYn+LsP4KsbwvS3aoFrmhE4jg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@wppconnect/wa-js/-/wa-js-4.6.0.tgz",
+      "integrity": "sha512-epf+ucZO9c25dCaGraslVNHB1mRjid7rfijZhKbalXed/gbDzi6u69wdHCgPbcZW9McVpKmVW+3AzffI39p2SQ==",
       "license": "Apache-2.0",
       "engines": {
-        "whatsapp-web": ">=2.2326.10-beta"
+        "whatsapp-web": ">=2.3000.1038792969-alpha"
       }
     },
     "node_modules/@wppconnect/wa-version": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@wppconnect/wa-js": "^4.4.3",
+    "@wppconnect/wa-js": "^4.6.0",
     "@wppconnect/wa-version": "^1.5.4472",
     "atob": "^2.1.2",
     "axios": "^1.18.1",


### PR DESCRIPTION
Bump `@wppconnect/wa-js` from `^4.4.3` to `^4.6.0`.

## Changes

- `package.json`: `@wppconnect/wa-js` `^4.4.3` → `^4.6.0`
- `package-lock.json`: updated accordingly

## Notes

- wa-js 4.6.0 requires `whatsapp-web >= 2.3000.1038792969-alpha`. The currently pinned `@wppconnect/wa-version@^1.5.4472` ships `2.3000.1044151668-alpha`, so no wa-version bump is needed.
- `npm run build` (webpack wapi + tsc) passes with no type errors.
