### PR TITLE
fix(changelog): restore full CHANGELOG history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.PERSONAL_TOKEN }}
+          # `changelog:update` walks the commits since the previous tag. On the
+          # default shallow clone it saw a single commit and no tags, so every
+          # release wrote a single bullet into CHANGELOG.md.
+          fetch-depth: 0
 
       - name: Setup GIT
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,586 +1,1311 @@
-## 2.2.7 (2026-08-10)
+## [2.2.7](https://github.com/wppconnect-team/wppconnect/compare/v2.2.6...v2.2.7) (2026-08-10)
 
 ### Bug Fixes
 
+- remove conflicting variable initialization ([#2848](https://github.com/wppconnect-team/wppconnect/issues/2848)) ([a3ce2c1](https://github.com/wppconnect-team/wppconnect/commit/a3ce2c1b8f4f297e50a00fd62816b6667faaf1d2))
 - remove unreachable group demotion return ([#2851](https://github.com/wppconnect-team/wppconnect/issues/2851)) ([eb57e3c](https://github.com/wppconnect-team/wppconnect/commit/eb57e3c32975871fc2191f0ca2d6a9e1609e268b))
+- resolve reliability control-flow warnings ([#2849](https://github.com/wppconnect-team/wppconnect/issues/2849)) ([ffe9318](https://github.com/wppconnect-team/wppconnect/commit/ffe9318b9eeb6d63d73cd85252565e5e8bf9917b))
+- **security:** remove vulnerable file detection chain ([#2847](https://github.com/wppconnect-team/wppconnect/issues/2847)) ([3401e2e](https://github.com/wppconnect-team/wppconnect/commit/3401e2e49cf6944cecdf88d80e296784deeaed7c))
 
-## 2.2.6 (2026-07-30)
+## [2.2.6](https://github.com/wppconnect-team/wppconnect/compare/v2.2.5...v2.2.6) (2026-07-30)
 
 ### Bug Fixes
 
 - **deps:** update dependency @wppconnect/wa-version to ^1.5.4472 ([#2833](https://github.com/wppconnect-team/wppconnect/issues/2833)) ([2513821](https://github.com/wppconnect-team/wppconnect/commit/2513821bb63172ac43f4e39ee3ecc98fd03009c3))
 
-## 2.2.5 (2026-07-30)
+## [2.2.5](https://github.com/wppconnect-team/wppconnect/compare/v2.2.4...v2.2.5) (2026-07-30)
 
 ### Bug Fixes
 
 - bump wa-js version to 4.4.3 ([#2832](https://github.com/wppconnect-team/wppconnect/issues/2832)) ([44ba830](https://github.com/wppconnect-team/wppconnect/commit/44ba83020d68a1a994b529f788662dd118abbaf3))
 
-## 2.2.4 (2026-07-24)
+## [2.2.4](https://github.com/wppconnect-team/wppconnect/compare/v2.2.3...v2.2.4) (2026-07-24)
 
 ### Bug Fixes
 
 - bump wa-js version to 4.4.2 ([#2829](https://github.com/wppconnect-team/wppconnect/issues/2829)) ([6677936](https://github.com/wppconnect-team/wppconnect/commit/6677936b75183d644808e5f2e5ae09bdee884ece))
 
-## 2.2.3 (2026-07-15)
+## [2.2.3](https://github.com/wppconnect-team/wppconnect/compare/v2.2.2...v2.2.3) (2026-07-15)
 
-## 2.2.2 (2026-07-15)
+## [2.2.2](https://github.com/wppconnect-team/wppconnect/compare/v2.2.1...v2.2.2) (2026-07-15)
 
-## 2.2.1 (2026-05-25)
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^4.3.1 ([#2810](https://github.com/wppconnect-team/wppconnect/issues/2810)) ([f8baa0c](https://github.com/wppconnect-team/wppconnect/commit/f8baa0c9898c672ebf2b3c05ff53e05f522302b3))
+
+## [2.2.1](https://github.com/wppconnect-team/wppconnect/compare/v2.2.0...v2.2.1) (2026-05-25)
 
 ### Bug Fixes
 
 - send media returning undefined ([#2792](https://github.com/wppconnect-team/wppconnect/issues/2792)) ([607fe8b](https://github.com/wppconnect-team/wppconnect/commit/607fe8be1897db34f5d1a87797a682897117114f))
 
-# 2.2.0 (2026-05-19)
+# [2.2.0](https://github.com/wppconnect-team/wppconnect/compare/v2.1.0...v2.2.0) (2026-05-19)
 
 ### Features
 
 - add ListsLayer for personal account chat grouping (WPP.lists) ([#2780](https://github.com/wppconnect-team/wppconnect/issues/2780)) ([dca5aa0](https://github.com/wppconnect-team/wppconnect/commit/dca5aa0c0dc6201b083a344c3c64a295eea77973))
 
-# 2.1.0 (2026-05-15)
+# [2.1.0](https://github.com/wppconnect-team/wppconnect/compare/v2.0.2...v2.1.0) (2026-05-15)
 
 ### Features
 
 - bump @wppconnect/wa-js to ^4.2.0 and @wppconnect/wa-version to ^1.5.3941 ([#2779](https://github.com/wppconnect-team/wppconnect/issues/2779)) ([3ec91eb](https://github.com/wppconnect-team/wppconnect/commit/3ec91eb11cda9cf3743307f17bb20366ba710301))
 
-## 2.0.2 (2026-05-04)
+## [2.0.2](https://github.com/wppconnect-team/wppconnect/compare/v2.0.1...v2.0.2) (2026-05-04)
 
 ### Bug Fixes
 
 - wa-js and axios version bump ([#2766](https://github.com/wppconnect-team/wppconnect/issues/2766)) ([d0e1421](https://github.com/wppconnect-team/wppconnect/commit/d0e1421a2e6b17e3a837909614fc0a53a17cd7f0))
 
-## 2.0.1 (2026-05-04)
+## [2.0.1](https://github.com/wppconnect-team/wppconnect/compare/v2.0.0...v2.0.1) (2026-05-04)
 
 ### Bug Fixes
 
 - tsconfig version to support spread operators natively and also fix the backendEvents ([#2764](https://github.com/wppconnect-team/wppconnect/issues/2764)) ([415926e](https://github.com/wppconnect-team/wppconnect/commit/415926e848c1717b91123debe9f6ce829b33280a))
 
-# 2.0.0 (2026-04-30)
+# [2.0.0](https://github.com/wppconnect-team/wppconnect/compare/v1.41.3...v2.0.0) (2026-04-30)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.3803 ([#2756](https://github.com/wppconnect-team/wppconnect/issues/2756)) ([5fa0289](https://github.com/wppconnect-team/wppconnect/commit/5fa02893a0afecd27b51631e20497828cd06e53f))
+- guard against undefined media in downloadMedia and improve error messages ([#2736](https://github.com/wppconnect-team/wppconnect/issues/2736)) ([#2737](https://github.com/wppconnect-team/wppconnect/issues/2737)) ([41acfa5](https://github.com/wppconnect-team/wppconnect/commit/41acfa53a050f46b88a50203244157e531ee9a33))
 
 ### Features
 
 - support to wa-js v4 ([#2759](https://github.com/wppconnect-team/wppconnect/issues/2759)) ([16d05cd](https://github.com/wppconnect-team/wppconnect/commit/16d05cd6b7078a3c0a78acc676a12057b28091cc))
 
-## 1.41.3 (2026-04-23)
+## [1.41.3](https://github.com/wppconnect-team/wppconnect/compare/v1.41.2...v1.41.3) (2026-04-23)
 
 ### Features
 
 - add optional viewMode and associationType property to Message interface ([#2755](https://github.com/wppconnect-team/wppconnect/issues/2755)) ([454128a](https://github.com/wppconnect-team/wppconnect/commit/454128a74c0afc2291b5a21beaa940cca35744dd))
 
-## 1.41.2 (2026-04-17)
+## [1.41.2](https://github.com/wppconnect-team/wppconnect/compare/v1.41.1...v1.41.2) (2026-04-17)
 
 ### Bug Fixes
 
 - **deps:** bump @wppconnect/wa-js to ^3.23.4 and @wppconnect/wa-version to ^1.5.3731 ([#2749](https://github.com/wppconnect-team/wppconnect/issues/2749)) ([3e5e1ed](https://github.com/wppconnect-team/wppconnect/commit/3e5e1edd5586ce5b82ae2c44485b898d84d7828a))
+- **deps:** update dependency @wppconnect/wa-js to ^3.23.3 ([#2745](https://github.com/wppconnect-team/wppconnect/issues/2745)) ([2d84581](https://github.com/wppconnect-team/wppconnect/commit/2d84581b4c1cdf2571649ff06b83f2f7cb175153))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.3483 ([#2720](https://github.com/wppconnect-team/wppconnect/issues/2720)) ([33d36b1](https://github.com/wppconnect-team/wppconnect/commit/33d36b19809e9bf499df245543bae091cc6733ec))
 
-## 1.41.1 (2026-03-18)
+## [1.41.1](https://github.com/wppconnect-team/wppconnect/compare/v1.41.0...v1.41.1) (2026-03-18)
 
 ### Bug Fixes
 
 - t is not a function ([#2718](https://github.com/wppconnect-team/wppconnect/issues/2718)) ([3d65a1c](https://github.com/wppconnect-team/wppconnect/commit/3d65a1cf0ff0ea70d38e79d9a2b788f1050845ed))
 
-# 1.41.0 (2026-03-05)
+# [1.41.0](https://github.com/wppconnect-team/wppconnect/compare/v1.40.1...v1.41.0) (2026-03-05)
 
 ### Features
 
 - exposing new stream events and bump wa-version lib ([#2716](https://github.com/wppconnect-team/wppconnect/issues/2716)) ([7c6355e](https://github.com/wppconnect-team/wppconnect/commit/7c6355e5f3e6b0cbeb2066dc3441c959be8d80f5))
 
-## 1.40.1 (2026-02-28)
+## [1.40.1](https://github.com/wppconnect-team/wppconnect/compare/v1.40.0...v1.40.1) (2026-02-28)
 
 ### Bug Fixes
 
 - bump wa-js version ([#2713](https://github.com/wppconnect-team/wppconnect/issues/2713)) ([4647644](https://github.com/wppconnect-team/wppconnect/commit/46476440010e8c12e02dbfb1ba962342c3c1a39e))
 
-# 1.40.0 (2026-02-27)
+# [1.40.0](https://github.com/wppconnect-team/wppconnect/compare/v1.39.0...v1.40.0) (2026-02-27)
 
 ### Features
 
 - add event listener for new chat and expose onNewChat method ([#2712](https://github.com/wppconnect-team/wppconnect/issues/2712)) ([081f355](https://github.com/wppconnect-team/wppconnect/commit/081f35543bac9181bccfc1e815b1c7c5e4123cdd))
 
-# 1.39.0 (2026-02-27)
+# [1.39.0](https://github.com/wppconnect-team/wppconnect/compare/v1.38.0...v1.39.0) (2026-02-27)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^3.20.1 ([#2680](https://github.com/wppconnect-team/wppconnect/issues/2680)) ([cdac369](https://github.com/wppconnect-team/wppconnect/commit/cdac3692ffa8478ce0556f2d60cb1581daea529a))
 
 ### Features
 
+- add IndexedDB functions for message retrieval by rowId ([#2709](https://github.com/wppconnect-team/wppconnect/issues/2709)) ([03fe90a](https://github.com/wppconnect-team/wppconnect/commit/03fe90ab0c254ef7178bdb131402149ecd4800e1))
 - update @wppconnect/wa-js to version 3.22.0 and refactor getMessagesFromRowId method ([#2710](https://github.com/wppconnect-team/wppconnect/issues/2710)) ([88c8457](https://github.com/wppconnect-team/wppconnect/commit/88c845786e419cd6e3187fe4e78cdfaf32f78cdd))
 
-## 1.38.0 (2026-01-21)
+# [1.38.0](https://github.com/wppconnect-team/wppconnect/compare/v1.37.11...v1.38.0) (2026-01-21)
 
-- feat(ui): add theme and auto download settings management methods (#2677) ([b2a63d3](https://github.com/wppconnect-team/wppconnect/commit/b2a63d3)), closes [#2677](https://github.com/wppconnect-team/wppconnect/issues/2677)
+### Bug Fixes
 
-## <small>1.37.11 (2026-01-19)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.20.0 ([#2675](https://github.com/wppconnect-team/wppconnect/issues/2675)) ([02428ae](https://github.com/wppconnect-team/wppconnect/commit/02428ae916b91209cebf77d5cb1f4ce27600c156))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.3099 ([#2674](https://github.com/wppconnect-team/wppconnect/issues/2674)) ([7614a22](https://github.com/wppconnect-team/wppconnect/commit/7614a22493f0fa199607568f8b1d2213130bdcf1))
 
-- chore(deps): update setup-node action to v6.2.0 and bump wa-version and puppeteer dependencies (#267 ([6da2727](https://github.com/wppconnect-team/wppconnect/commit/6da2727)), closes [#2670](https://github.com/wppconnect-team/wppconnect/issues/2670)
+### Features
 
-## <small>1.37.10 (2026-01-19)</small>
+- **ui:** add theme and auto download settings management methods ([#2677](https://github.com/wppconnect-team/wppconnect/issues/2677)) ([b2a63d3](https://github.com/wppconnect-team/wppconnect/commit/b2a63d3cdc609f640b1b151a210f99bd5f3f6525))
 
-- Merge pull request #2629 from uriva/master ([61670a9](https://github.com/wppconnect-team/wppconnect/commit/61670a9)), closes [#2629](https://github.com/wppconnect-team/wppconnect/issues/2629)
+## [1.37.11](https://github.com/wppconnect-team/wppconnect/compare/v1.37.10...v1.37.11) (2026-01-19)
 
-## <small>1.37.9 (2026-01-05)</small>
+### Bug Fixes
 
-- fix: Upgrade whatsapp version ([5a02155](https://github.com/wppconnect-team/wppconnect/commit/5a02155))
+- **deps:** update dependency @wppconnect/wa-js to ^3.19.8 ([#2668](https://github.com/wppconnect-team/wppconnect/issues/2668)) ([3fedb04](https://github.com/wppconnect-team/wppconnect/commit/3fedb044635c7bb1321f83da1e1311abf4607023))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.3081 ([#2669](https://github.com/wppconnect-team/wppconnect/issues/2669)) ([360c7cd](https://github.com/wppconnect-team/wppconnect/commit/360c7cd64859305a93187aaf46e2020c728d4982))
 
-## <small>1.37.8 (2025-11-26)</small>
+## [1.37.10](https://github.com/wppconnect-team/wppconnect/compare/v1.37.9...v1.37.10) (2026-01-19)
 
-- Merge pull request #2628 from wppconnect-team/manfe/bump-wa-js-versions ([f4117cb](https://github.com/wppconnect-team/wppconnect/commit/f4117cb)), closes [#2628](https://github.com/wppconnect-team/wppconnect/issues/2628)
+### Bug Fixes
 
-## <small>1.37.7 (2025-11-25)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.19.6 ([#2663](https://github.com/wppconnect-team/wppconnect/issues/2663)) ([eb85649](https://github.com/wppconnect-team/wppconnect/commit/eb85649744b697f3247037c3158dabe1aa46ccf6))
+- **deps:** update dependency @wppconnect/wa-js to ^3.19.7 ([#2666](https://github.com/wppconnect-team/wppconnect/issues/2666)) ([70a833e](https://github.com/wppconnect-team/wppconnect/commit/70a833e9504935d8ef6505e313ce7abcb5cf78fb))
 
-- Merge pull request #2624 from wppconnect-team/manfe/bump-wa-js-versions ([eb652cf](https://github.com/wppconnect-team/wppconnect/commit/eb652cf)), closes [#2624](https://github.com/wppconnect-team/wppconnect/issues/2624)
+## [1.37.9](https://github.com/wppconnect-team/wppconnect/compare/v1.37.8...v1.37.9) (2026-01-05)
 
-## <small>1.37.6 (2025-11-11)</small>
+### Bug Fixes
 
-- [update] version whatsapp web (#2609) ([cf04c5d](https://github.com/wppconnect-team/wppconnect/commit/cf04c5d)), closes [#2609](https://github.com/wppconnect-team/wppconnect/issues/2609)
+- **deps:** update dependency @wppconnect/wa-js to ^3.19.4 ([#2653](https://github.com/wppconnect-team/wppconnect/issues/2653)) ([05ef967](https://github.com/wppconnect-team/wppconnect/commit/05ef967e33f34a7586795876b34d7e755471af5f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.2811 ([#2638](https://github.com/wppconnect-team/wppconnect/issues/2638)) ([cb00d84](https://github.com/wppconnect-team/wppconnect/commit/cb00d84abba5520c844e37e87e9031ab40fd155c))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.2981 ([#2654](https://github.com/wppconnect-team/wppconnect/issues/2654)) ([f3be1eb](https://github.com/wppconnect-team/wppconnect/commit/f3be1eb7a1362a324366fe6d771349c39635a54d))
+- Upgrade whatsapp version ([5a02155](https://github.com/wppconnect-team/wppconnect/commit/5a02155b007998a2155d6fbd59d2e71df6dc469e))
 
-## <small>1.37.5 (2025-09-16)</small>
+## [1.37.8](https://github.com/wppconnect-team/wppconnect/compare/v1.37.7...v1.37.8) (2025-11-26)
 
-- chore: update wajs ([9b3f4d5](https://github.com/wppconnect-team/wppconnect/commit/9b3f4d5))
+## [1.37.7](https://github.com/wppconnect-team/wppconnect/compare/v1.37.6...v1.37.7) (2025-11-25)
 
-## <small>1.37.4 (2025-08-29)</small>
+### Bug Fixes
 
-- fix(deps): update dependency @wppconnect/wa-version to ^1.5.2110 (#2555) ([baad13c](https://github.com/wppconnect-team/wppconnect/commit/baad13c)), closes [#2555](https://github.com/wppconnect-team/wppconnect/issues/2555)
+- fix husky version migration issue ([75246dd](https://github.com/wppconnect-team/wppconnect/commit/75246ddaf9c33ada9d01a6e23fdb91a053d553a0))
 
-## <small>1.37.3 (2025-07-08)</small>
+### Features
 
-- fix(deps): update dependency @wppconnect/wa-version to ^1.5.1804 (#2514) ([0503c9f](https://github.com/wppconnect-team/wppconnect/commit/0503c9f)), closes [#2514](https://github.com/wppconnect-team/wppconnect/issues/2514)
+- add isLidMigrated method to check account migration status ([e6f5ad4](https://github.com/wppconnect-team/wppconnect/commit/e6f5ad4aab6bc200880da96f48db8d7b45596b43))
 
-## <small>1.37.2 (2025-05-28)</small>
+## [1.37.6](https://github.com/wppconnect-team/wppconnect/compare/v1.37.5...v1.37.6) (2025-11-11)
 
-- fix: Upgrade whatsappversion ([9c06639](https://github.com/wppconnect-team/wppconnect/commit/9c06639))
+### Bug Fixes
 
-## <small>1.37.1 (2025-05-01)</small>
+- add isPtt parameter to sendPtt method for improved audio message handling ([#2593](https://github.com/wppconnect-team/wppconnect/issues/2593)) ([3f50dc6](https://github.com/wppconnect-team/wppconnect/commit/3f50dc6efb69a51c4d107c297024d2020e6a704d))
+- chat opening methods accept a Wid param ([#2411](https://github.com/wppconnect-team/wppconnect/issues/2411)) ([514685a](https://github.com/wppconnect-team/wppconnect/commit/514685afe5c45e1702d2c2f26c96f282ecbc55f8))
+- **deps:** update dependency @wppconnect/wa-js to ^3.18.6 ([#2574](https://github.com/wppconnect-team/wppconnect/issues/2574)) ([adbd215](https://github.com/wppconnect-team/wppconnect/commit/adbd2158caa0d42dfff8aac3c0da06603a85fc9c))
+- Upgrade whatsappVersion ([a08e914](https://github.com/wppconnect-team/wppconnect/commit/a08e9144f78d2a3375e32f45b6d20fbc9054c5ec))
 
-- fix(deps): update dependency @wppconnect/wa-js to ^3.17.2 (#2490) ([95a6d9e](https://github.com/wppconnect-team/wppconnect/commit/95a6d9e)), closes [#2490](https://github.com/wppconnect-team/wppconnect/issues/2490)
+### Features
 
-## 1.37.0 (2025-04-15)
+- add isPtt parameter to sendPtt and sendPttFromBase64 methods ([#2570](https://github.com/wppconnect-team/wppconnect/issues/2570)) ([73063c1](https://github.com/wppconnect-team/wppconnect/commit/73063c1fa2be1f09ce90bc84152abf92e2f62b75))
 
-- build(deps-dev): update dependency @types/node to ^20.17.30 (#2481) ([dcd6088](https://github.com/wppconnect-team/wppconnect/commit/dcd6088)), closes [#2481](https://github.com/wppconnect-team/wppconnect/issues/2481)
+### Reverts
 
-## <small>1.36.4 (2025-03-29)</small>
+- Revert "Fix: Forwarding message now really support array of messages (#2592)" (#2599) ([1322e19](https://github.com/wppconnect-team/wppconnect/commit/1322e19293051627e1652d2ec46253bbc2d4b9c8)), closes [#2592](https://github.com/wppconnect-team/wppconnect/issues/2592) [#2599](https://github.com/wppconnect-team/wppconnect/issues/2599)
 
-- fix(deps): update dependency @wppconnect/wa-js to ^3.17.0 (#2473) ([597a6ac](https://github.com/wppconnect-team/wppconnect/commit/597a6ac)), closes [#2473](https://github.com/wppconnect-team/wppconnect/issues/2473)
+## [1.37.5](https://github.com/wppconnect-team/wppconnect/compare/v1.37.4...v1.37.5) (2025-09-16)
 
-## <small>1.36.3 (2025-03-27)</small>
+### Bug Fixes
 
-- fix(deps): update dependency @wppconnect/wa-version to ^1.5.1244 (#2471) ([b83713c](https://github.com/wppconnect-team/wppconnect/commit/b83713c)), closes [#2471](https://github.com/wppconnect-team/wppconnect/issues/2471)
+- **deps:** update dependency @wppconnect/wa-js to ^3.18.4 ([#2567](https://github.com/wppconnect-team/wppconnect/issues/2567)) ([6a1f193](https://github.com/wppconnect-team/wppconnect/commit/6a1f1938c37074eed66c2d1826c36962b899224e))
 
-## <small>1.36.2 (2025-03-26)</small>
+## [1.37.4](https://github.com/wppconnect-team/wppconnect/compare/v1.37.3...v1.37.4) (2025-08-29)
 
-- fix: Fixed lint errors ([73da91f](https://github.com/wppconnect-team/wppconnect/commit/73da91f))
+### Bug Fixes
 
-## <small>1.36.1 (2025-03-21)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.18.0 ([#2540](https://github.com/wppconnect-team/wppconnect/issues/2540)) ([425dfd7](https://github.com/wppconnect-team/wppconnect/commit/425dfd7f61f165507563fe6c7cebb5baff7d6dfd))
+- **deps:** update dependency @wppconnect/wa-js to ^3.18.1 ([#2554](https://github.com/wppconnect-team/wppconnect/issues/2554)) ([6c08f5a](https://github.com/wppconnect-team/wppconnect/commit/6c08f5a9b5123622a0628664f75c63369d6466a7))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.2104 ([#2553](https://github.com/wppconnect-team/wppconnect/issues/2553)) ([a70fb46](https://github.com/wppconnect-team/wppconnect/commit/a70fb465e07847f1e6fe4bdaa020f6a6a877d8e0))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.2110 ([#2555](https://github.com/wppconnect-team/wppconnect/issues/2555)) ([baad13c](https://github.com/wppconnect-team/wppconnect/commit/baad13c7b98b7bebe1ae2921e53890b440824073))
+- Upgrade whatsappVersion ([62ecb59](https://github.com/wppconnect-team/wppconnect/commit/62ecb59e9b61820a64ab273b4c95a3413e64f28e))
 
-- chore: update workflow for launch release ([7dd3739](https://github.com/wppconnect-team/wppconnect/commit/7dd3739))
+## [1.37.3](https://github.com/wppconnect-team/wppconnect/compare/v1.37.2...v1.37.3) (2025-07-08)
 
-## 1.36.0 (2025-03-21)
+### Bug Fixes
 
-- feat: Added client.onMessageEdit event (close #2092) ([874f8c4](https://github.com/wppconnect-team/wppconnect/commit/874f8c4)), closes [#2092](https://github.com/wppconnect-team/wppconnect/issues/2092)
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1804 ([#2514](https://github.com/wppconnect-team/wppconnect/issues/2514)) ([0503c9f](https://github.com/wppconnect-team/wppconnect/commit/0503c9f4e4234e51d8ab40467e71c0eb4c4c464c))
+- Upgrade whatsappVersion ([aebd920](https://github.com/wppconnect-team/wppconnect/commit/aebd9207f67a1114de331cd875b7f8024d76afc6))
 
-## <small>1.35.2 (2024-12-20)</small>
+## [1.37.2](https://github.com/wppconnect-team/wppconnect/compare/v1.37.1...v1.37.2) (2025-05-28)
 
-- fix(deps): update dependency @wppconnect/wa-js to ^3.16.0 (#2425) ([28384fd](https://github.com/wppconnect-team/wppconnect/commit/28384fd)), closes [#2425](https://github.com/wppconnect-team/wppconnect/issues/2425)
+### Bug Fixes
 
-## <small>1.35.1 (2024-10-30)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.17.7 ([#2499](https://github.com/wppconnect-team/wppconnect/issues/2499)) ([d9ab069](https://github.com/wppconnect-team/wppconnect/commit/d9ab0691ed37f8e6c37d02471d76fbd302cbf034))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1587 ([#2500](https://github.com/wppconnect-team/wppconnect/issues/2500)) ([794589d](https://github.com/wppconnect-team/wppconnect/commit/794589d3cce62c03ca11c38c0ebb9991a894b506))
+- Upgrade whatsappversion ([9c06639](https://github.com/wppconnect-team/wppconnect/commit/9c06639ea4d11751928d93cc27a67cc8900c7100))
 
-- fix: Upgrade whatsappVersion to 2.3000.10173x ([2b609f5](https://github.com/wppconnect-team/wppconnect/commit/2b609f5))
+## [1.37.1](https://github.com/wppconnect-team/wppconnect/compare/v1.37.0...v1.37.1) (2025-05-01)
 
-## 1.35.0 (2024-10-24)
+### Bug Fixes
 
-- fix(deps): update dependency @wppconnect/wa-version to ^1.5.557 (#2399) ([4bc22a5](https://github.com/wppconnect-team/wppconnect/commit/4bc22a5)), closes [#2399](https://github.com/wppconnect-team/wppconnect/issues/2399)
+- **deps:** update dependency @wppconnect/wa-js to ^3.17.2 ([#2490](https://github.com/wppconnect-team/wppconnect/issues/2490)) ([95a6d9e](https://github.com/wppconnect-team/wppconnect/commit/95a6d9e36c0d7fa89a70c49d30ea25a5b57f9418))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1433 ([#2491](https://github.com/wppconnect-team/wppconnect/issues/2491)) ([389c50f](https://github.com/wppconnect-team/wppconnect/commit/389c50fa65f81064dccb081b494ad175884481ff))
 
-## <small>1.34.2 (2024-09-27)</small>
+# [1.37.0](https://github.com/wppconnect-team/wppconnect/compare/v1.36.4...v1.37.0) (2025-04-15)
 
-- build(deps): update dependency puppeteer to ^23.4.1 (#2349) ([fe16137](https://github.com/wppconnect-team/wppconnect/commit/fe16137)), closes [#2349](https://github.com/wppconnect-team/wppconnect/issues/2349)
+### Bug Fixes
 
-## <small>1.34.1 (2024-09-09)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.17.1 ([#2483](https://github.com/wppconnect-team/wppconnect/issues/2483)) ([2973e67](https://github.com/wppconnect-team/wppconnect/commit/2973e67e935cc4d86308f0b64562a3db239b88b3))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1355 ([#2484](https://github.com/wppconnect-team/wppconnect/issues/2484)) ([ef267c6](https://github.com/wppconnect-team/wppconnect/commit/ef267c6923d8cfee3174a0b80587109c4f844064))
 
-- chore: rollback typedoc ([077ff9b](https://github.com/wppconnect-team/wppconnect/commit/077ff9b))
+### Features
 
-## 1.34.0 (2024-09-09)
+- Added sendPixKey function ([5562b75](https://github.com/wppconnect-team/wppconnect/commit/5562b75a7cecf7731fa533867e0290aa79f52e93))
 
-- fix(deps): update dependency @wppconnect/wa-js to ^3.10.1 (#2336) ([cc29475](https://github.com/wppconnect-team/wppconnect/commit/cc29475)), closes [#2336](https://github.com/wppconnect-team/wppconnect/issues/2336)
+## [1.36.4](https://github.com/wppconnect-team/wppconnect/compare/v1.36.3...v1.36.4) (2025-03-29)
 
-## <small>1.33.1 (2024-08-30)</small>
+### Bug Fixes
 
-- fix: Fixed client.openChatAt (close #2293) ([68e011c](https://github.com/wppconnect-team/wppconnect/commit/68e011c)), closes [#2293](https://github.com/wppconnect-team/wppconnect/issues/2293)
+- **deps:** update dependency @wppconnect/wa-js to ^3.17.0 ([#2473](https://github.com/wppconnect-team/wppconnect/issues/2473)) ([597a6ac](https://github.com/wppconnect-team/wppconnect/commit/597a6ac68ce6b170dc382c4ae7ddd80751fa0355))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1261 ([#2472](https://github.com/wppconnect-team/wppconnect/issues/2472)) ([d7a0f79](https://github.com/wppconnect-team/wppconnect/commit/d7a0f7923840cec2a0dd926a85b4f1d1089e0764))
+- Upgrade whatsappVersion ([988e922](https://github.com/wppconnect-team/wppconnect/commit/988e922dc213dbf2a1b24ae4092b1ad2ebef0601))
 
-## 1.33.0 (2024-08-05)
+## [1.36.3](https://github.com/wppconnect-team/wppconnect/compare/v1.36.2...v1.36.3) (2025-03-27)
 
-- feat: Added client.closeChat function (close #2271) (#2290) ([539e5d9](https://github.com/wppconnect-team/wppconnect/commit/539e5d9)), closes [#2271](https://github.com/wppconnect-team/wppconnect/issues/2271) [#2290](https://github.com/wppconnect-team/wppconnect/issues/2290)
+### Bug Fixes
 
-## <small>1.32.4 (2024-07-16)</small>
+- **deps:** update dependency @wppconnect/wa-js to ^3.16.9 ([#2470](https://github.com/wppconnect-team/wppconnect/issues/2470)) ([ed53524](https://github.com/wppconnect-team/wppconnect/commit/ed5352436e89c2a0f773b7b4fb54e45e2d8f4e7d))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1244 ([#2471](https://github.com/wppconnect-team/wppconnect/issues/2471)) ([b83713c](https://github.com/wppconnect-team/wppconnect/commit/b83713cc070ac07dc526226703d62ce044bdd434))
 
-- fix(deps): update dependency @wppconnect/wa-js to ^3.6.0 (#2275) ([4d56011](https://github.com/wppconnect-team/wppconnect/commit/4d56011)), closes [#2275](https://github.com/wppconnect-team/wppconnect/issues/2275)
+## [1.36.2](https://github.com/wppconnect-team/wppconnect/compare/v1.36.1...v1.36.2) (2025-03-26)
 
-## <small>1.32.3 (2024-06-24)</small>
+### Bug Fixes
 
-- chore: upgrade @wppconnect/wa-js ([50775a8](https://github.com/wppconnect-team/wppconnect/commit/50775a8))
+- **deps:** update dependency @wppconnect/wa-js to ^3.16.8 ([#2468](https://github.com/wppconnect-team/wppconnect/issues/2468)) ([94cdedf](https://github.com/wppconnect-team/wppconnect/commit/94cdedf1471993615a3b27306a7d5bdd24526eeb))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1243 ([#2467](https://github.com/wppconnect-team/wppconnect/issues/2467)) ([cc20094](https://github.com/wppconnect-team/wppconnect/commit/cc20094ec0c4d425124f4f5ec9dfb586e22308a4))
+- ensure 'options' is always defined when sendImage and sendImageFromBase64 ([#2464](https://github.com/wppconnect-team/wppconnect/issues/2464)) ([5165c80](https://github.com/wppconnect-team/wppconnect/commit/5165c80c18980452abf65978e383c561940e9963))
+- Fixed lint errors ([73da91f](https://github.com/wppconnect-team/wppconnect/commit/73da91f7a576fcf43a371b6681f4e6bf5824f7f0))
 
-## <small>1.32.2 (2024-06-18)</small>
+## [1.36.1](https://github.com/wppconnect-team/wppconnect/compare/v1.36.0...v1.36.1) (2025-03-21)
 
-- chore: Remove unused deps ([a600ce0](https://github.com/wppconnect-team/wppconnect/commit/a600ce0))
+### Bug Fixes
 
-## <small>1.32.1 (2024-06-17)</small>
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1217 ([#2462](https://github.com/wppconnect-team/wppconnect/issues/2462)) ([7320fa9](https://github.com/wppconnect-team/wppconnect/commit/7320fa966e1b1783814d5dba54b2f1af88eea92c))
+- Fixed onLoadingScreen function for new whatsapp theme (close [#2437](https://github.com/wppconnect-team/wppconnect/issues/2437)) ([88dbf3f](https://github.com/wppconnect-team/wppconnect/commit/88dbf3fbf821ffd9997f4ee7240bb16809062404))
+- fixed typos in sendTextStatus (close [#2427](https://github.com/wppconnect-team/wppconnect/issues/2427)) ([d857c7f](https://github.com/wppconnect-team/wppconnect/commit/d857c7f3b360f64bd5602f3adbf6b85f3cf37a64))
+- Improovment sendImage with custom id ([9b07d1b](https://github.com/wppconnect-team/wppconnect/commit/9b07d1be1e51e109aa028ddfd32230aab92931ff))
 
-- fix: Fixed emitting events ([95e934d](https://github.com/wppconnect-team/wppconnect/commit/95e934d))
+# [1.36.0](https://github.com/wppconnect-team/wppconnect/compare/v1.35.2...v1.36.0) (2025-03-21)
 
-## 1.32.0 (2024-06-12)
+### Bug Fixes
 
-- fix: Improovment whatsappVersion to 2.3000.10139x ([d246c58](https://github.com/wppconnect-team/wppconnect/commit/d246c58))
+- **deps:** update dependency @wppconnect/wa-js to ^3.16.3 ([#2430](https://github.com/wppconnect-team/wppconnect/issues/2430)) ([0355e88](https://github.com/wppconnect-team/wppconnect/commit/0355e882d968a10320fe3c49409beed2be3268ff))
+- **deps:** update dependency @wppconnect/wa-js to ^3.16.6 ([#2446](https://github.com/wppconnect-team/wppconnect/issues/2446)) ([6c2bdc5](https://github.com/wppconnect-team/wppconnect/commit/6c2bdc53b99f64248bc47dade4504c9025846ec9))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.1206 ([#2451](https://github.com/wppconnect-team/wppconnect/issues/2451)) ([b885c6c](https://github.com/wppconnect-team/wppconnect/commit/b885c6c2d6c73d09e8702e3e277ec217e4c65c22))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.997 ([#2431](https://github.com/wppconnect-team/wppconnect/issues/2431)) ([4dad63b](https://github.com/wppconnect-team/wppconnect/commit/4dad63be3855b0bbc21d18602fa4d5913c6b7c2d))
+- Upgrade whatsappVersion ([e2fcd6c](https://github.com/wppconnect-team/wppconnect/commit/e2fcd6cc19b8014820edd0cebe0aee65833ed610))
 
-## 1.31.1 (2024-06-12)
+### Features
+
+- Added client.decryptAndSaveFile function ([f42ffd7](https://github.com/wppconnect-team/wppconnect/commit/f42ffd7699add52befa70cd71e6cb5ce19389483))
+- Added client.onMessageEdit event (close [#2092](https://github.com/wppconnect-team/wppconnect/issues/2092)) ([874f8c4](https://github.com/wppconnect-team/wppconnect/commit/874f8c470d16ccbd29ddf10e669db5df5ee5d5f3))
+
+## [1.35.2](https://github.com/wppconnect-team/wppconnect/compare/v1.35.1...v1.35.2) (2024-12-20)
+
+### Bug Fixes
+
+- Added new notification subtype (group creation) ([#2406](https://github.com/wppconnect-team/wppconnect/issues/2406)) ([6693eb7](https://github.com/wppconnect-team/wppconnect/commit/6693eb7acc7514ea40a586bc73bf344f39a4df6c))
+- **deps:** update dependency @wppconnect/wa-js to ^3.16.0 ([#2425](https://github.com/wppconnect-team/wppconnect/issues/2425)) ([28384fd](https://github.com/wppconnect-team/wppconnect/commit/28384fd92ac4a131caf76d3ef1fb36f1dbc06cde))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.828 ([#2423](https://github.com/wppconnect-team/wppconnect/issues/2423)) ([fa16a02](https://github.com/wppconnect-team/wppconnect/commit/fa16a024f762264bcadb72888d0ec91d0e70ea49))
+- Fixed notSpam attribute of Chat is optional ([#2416](https://github.com/wppconnect-team/wppconnect/issues/2416)) ([6f7f328](https://github.com/wppconnect-team/wppconnect/commit/6f7f328c968df38d72d53e732043fc698f50ebf1))
+- Upgrade whatsappVersion to 2.3000.10177x ([39df0d3](https://github.com/wppconnect-team/wppconnect/commit/39df0d317a40422f6b14eb49bf7b450e319cecfc))
+- Upgrade whatsappVersion to 2.3000.10187x ([0b8c9ae](https://github.com/wppconnect-team/wppconnect/commit/0b8c9aeb9cf726da9c48e4163cc50c7c1ea1e284))
+
+## [1.35.1](https://github.com/wppconnect-team/wppconnect/compare/v1.35.0...v1.35.1) (2024-10-30)
+
+### Bug Fixes
+
+- Upgrade whatsappVersion to 2.3000.10173x ([2b609f5](https://github.com/wppconnect-team/wppconnect/commit/2b609f5d8293acba76ba723ba050bae768f8f826))
+
+# [1.35.0](https://github.com/wppconnect-team/wppconnect/compare/v1.34.2...v1.35.0) (2024-10-24)
+
+### Bug Fixes
+
+- Add 'isViewOnce' in message interface ([#2359](https://github.com/wppconnect-team/wppconnect/issues/2359)) ([cd9a10b](https://github.com/wppconnect-team/wppconnect/commit/cd9a10b8eca851ddd595bb3a38b7cf15e93e6a50))
+- Added missing group chat properties ([#2362](https://github.com/wppconnect-team/wppconnect/issues/2362)) ([9fbc5ae](https://github.com/wppconnect-team/wppconnect/commit/9fbc5aeaba577bbdce8c1e1be5ba87e642c463b7))
+- **deps:** update dependency @wppconnect/wa-js to ^3.10.2 ([5193a50](https://github.com/wppconnect-team/wppconnect/commit/5193a50e682f93c71117ec5db1e81941d539b7ac))
+- **deps:** update dependency @wppconnect/wa-js to ^3.12.0 ([a521c5e](https://github.com/wppconnect-team/wppconnect/commit/a521c5ef3a87f673578866c21ab1fa721441599e))
+- **deps:** update dependency @wppconnect/wa-js to ^3.12.1 ([#2398](https://github.com/wppconnect-team/wppconnect/issues/2398)) ([5b0a198](https://github.com/wppconnect-team/wppconnect/commit/5b0a198e783728197101c3db54b60d7c4e714ceb))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.519 ([1279697](https://github.com/wppconnect-team/wppconnect/commit/12796975df4704ea8fd4022f2443302feca843df))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.556 ([#2396](https://github.com/wppconnect-team/wppconnect/issues/2396)) ([b17e558](https://github.com/wppconnect-team/wppconnect/commit/b17e558f42c121e371ec358e3e517e1c45f3206e))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.557 ([#2399](https://github.com/wppconnect-team/wppconnect/issues/2399)) ([4bc22a5](https://github.com/wppconnect-team/wppconnect/commit/4bc22a5c86a6c111b8da7e72ef0f291eee167c03))
+- enhanced type definition for recipients of the sendFile method ([e20fb63](https://github.com/wppconnect-team/wppconnect/commit/e20fb63b943d2adcd2b582cf6728cdd2d1f05e90))
+- Fixed getActiveChat is not async ([#2350](https://github.com/wppconnect-team/wppconnect/issues/2350)) ([1230a12](https://github.com/wppconnect-team/wppconnect/commit/1230a12082584de9d781beaed00ed9d6c76eece7))
+- Fixed getChatById typos ([#2353](https://github.com/wppconnect-team/wppconnect/issues/2353)) ([697feb1](https://github.com/wppconnect-team/wppconnect/commit/697feb1b172d0220432dbd383151367fc3c9ed33))
+- Fixed parent group Id missing in group metadata ([#2351](https://github.com/wppconnect-team/wppconnect/issues/2351)) ([1a40579](https://github.com/wppconnect-team/wppconnect/commit/1a40579384e932566396abbfb81e093dfe201e59))
+
+### Features
+
+- Added client.getProfileStatus function ([#2364](https://github.com/wppconnect-team/wppconnect/issues/2364)) ([4ce63d8](https://github.com/wppconnect-team/wppconnect/commit/4ce63d8f24b5147be045c0d50687e5a4785af72a))
+- Added proxy authentication ([#2354](https://github.com/wppconnect-team/wppconnect/issues/2354)) ([f0f0406](https://github.com/wppconnect-team/wppconnect/commit/f0f0406188ae8fdd94b5534bc62733e0cdfdff90))
+
+## [1.34.2](https://github.com/wppconnect-team/wppconnect/compare/v1.34.1...v1.34.2) (2024-09-27)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.355 ([09369c6](https://github.com/wppconnect-team/wppconnect/commit/09369c6d135552086d1e703a4bdcc2fe8e64030c))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.416 ([#2348](https://github.com/wppconnect-team/wppconnect/issues/2348)) ([a4b8462](https://github.com/wppconnect-team/wppconnect/commit/a4b846298e36b37c9c1a406dbb2ffbcda51cf18c))
+- Upgrade whatsappVersion to 2.3000.10162x ([a51ff3d](https://github.com/wppconnect-team/wppconnect/commit/a51ff3d40e45a80ca07d8b565eeef52bb772edb1))
+
+## [1.34.1](https://github.com/wppconnect-team/wppconnect/compare/v1.34.0...v1.34.1) (2024-09-09)
+
+# [1.34.0](https://github.com/wppconnect-team/wppconnect/compare/v1.33.1...v1.34.0) (2024-09-09)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^3.10.0 ([30018c6](https://github.com/wppconnect-team/wppconnect/commit/30018c6afab15b2688e3bfe05146ba4158ee6a56))
+- **deps:** update dependency @wppconnect/wa-js to ^3.10.1 ([#2336](https://github.com/wppconnect-team/wppconnect/issues/2336)) ([cc29475](https://github.com/wppconnect-team/wppconnect/commit/cc2947527029bf4d1fe3fc28221d468e6d9ce156))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.321 ([#2328](https://github.com/wppconnect-team/wppconnect/issues/2328)) ([0bbde51](https://github.com/wppconnect-team/wppconnect/commit/0bbde51b320a00087c09abc178372e796e7a9523))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.323 ([#2333](https://github.com/wppconnect-team/wppconnect/issues/2333)) ([8273cee](https://github.com/wppconnect-team/wppconnect/commit/8273cee3bffad2fcff274bb2e1d3d0df670894cf))
+
+## [1.33.1](https://github.com/wppconnect-team/wppconnect/compare/v1.33.0...v1.33.1) (2024-08-30)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.174 ([42dc3ae](https://github.com/wppconnect-team/wppconnect/commit/42dc3aee4da0c14aeace516a15c3da5664d1c8f0))
+- Fixed client.openChatAt (close [#2293](https://github.com/wppconnect-team/wppconnect/issues/2293)) ([68e011c](https://github.com/wppconnect-team/wppconnect/commit/68e011c7424ec5dc85d67c58c6864ad6642c1bd6))
+- Upgrade whatsappVersion to 2.3000.10156x ([7e88c51](https://github.com/wppconnect-team/wppconnect/commit/7e88c510de4671ae21e1ad81e07efb50a80a1947))
+
+# [1.33.0](https://github.com/wppconnect-team/wppconnect/compare/v1.32.4...v1.33.0) (2024-08-05)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^3.7.0 ([9437bd4](https://github.com/wppconnect-team/wppconnect/commit/9437bd4f06888c5a78221f6f75872d3238a5ae52))
+- **deps:** update dependency @wppconnect/wa-js to ^3.8.1 ([#2304](https://github.com/wppconnect-team/wppconnect/issues/2304)) ([c171611](https://github.com/wppconnect-team/wppconnect/commit/c171611ee0febe96dd3c96bbb2b5615a51408142))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.100 ([#2281](https://github.com/wppconnect-team/wppconnect/issues/2281)) ([7f1960d](https://github.com/wppconnect-team/wppconnect/commit/7f1960d12c950a6b2ed4c5d53e95fa1ca852cc8a))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.154 ([#2300](https://github.com/wppconnect-team/wppconnect/issues/2300)) ([2cf7266](https://github.com/wppconnect-team/wppconnect/commit/2cf726628d6a6533636f1ada46e985f41d818403))
+- Fixed send order message ([577426f](https://github.com/wppconnect-team/wppconnect/commit/577426f5bc4358c5534d89a77b7083c1dd9f11d4))
+- Upgrade whatsappVersion to 2.3000.10152x ([55137ad](https://github.com/wppconnect-team/wppconnect/commit/55137ada862a6c6006aee7ad00adbacfa8f9d965))
+
+### Features
+
+- Added client.closeChat function (close [#2271](https://github.com/wppconnect-team/wppconnect/issues/2271)) ([#2290](https://github.com/wppconnect-team/wppconnect/issues/2290)) ([539e5d9](https://github.com/wppconnect-team/wppconnect/commit/539e5d9c2abf4ed5d389c6c2a12d3ac0d8e5f7bc))
+- added client.getProfileName function ([#2288](https://github.com/wppconnect-team/wppconnect/issues/2288)) ([8f7ec63](https://github.com/wppconnect-team/wppconnect/commit/8f7ec632f635448660a1156e023d3aa8569ed456))
+
+## [1.32.4](https://github.com/wppconnect-team/wppconnect/compare/v1.32.3...v1.32.4) (2024-07-16)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^3.5.0 ([#2264](https://github.com/wppconnect-team/wppconnect/issues/2264)) ([3cd6309](https://github.com/wppconnect-team/wppconnect/commit/3cd6309fd139400a085aac86c12f675a4ffd460a))
+- **deps:** update dependency @wppconnect/wa-js to ^3.6.0 ([#2275](https://github.com/wppconnect-team/wppconnect/issues/2275)) ([4d56011](https://github.com/wppconnect-team/wppconnect/commit/4d560113d6c38508fe2449baa9960a3370d54e05))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.71 ([#2261](https://github.com/wppconnect-team/wppconnect/issues/2261)) ([f30c15c](https://github.com/wppconnect-team/wppconnect/commit/f30c15cf17f59a0bea2dedf654ebf25d1d1609c1))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.87 ([#2272](https://github.com/wppconnect-team/wppconnect/issues/2272)) ([c4b79f6](https://github.com/wppconnect-team/wppconnect/commit/c4b79f697e3059f8c20a8e87f946a2180ba388ee))
+- Upgrade WhatsApp web version to 2.3000.10147x ([8f64054](https://github.com/wppconnect-team/wppconnect/commit/8f6405476ad4171763408bc1055d529663147390))
+
+## [1.32.3](https://github.com/wppconnect-team/wppconnect/compare/v1.32.2...v1.32.3) (2024-06-24)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.26 ([c1e094c](https://github.com/wppconnect-team/wppconnect/commit/c1e094c9c409e2d1a6071056ead10221cdf9d310))
+- Improovment get order by wajs ([40574ed](https://github.com/wppconnect-team/wppconnect/commit/40574ed5054f0cb2f6fc1acb0f686e6d2d89447b))
+
+## [1.32.2](https://github.com/wppconnect-team/wppconnect/compare/v1.32.1...v1.32.2) (2024-06-18)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^3.3.2 ([#2231](https://github.com/wppconnect-team/wppconnect/issues/2231)) ([66a8c48](https://github.com/wppconnect-team/wppconnect/commit/66a8c48be4c8a997c6f8c81ac0884414c3cadd4f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.10 ([#2223](https://github.com/wppconnect-team/wppconnect/issues/2223)) ([be579cc](https://github.com/wppconnect-team/wppconnect/commit/be579cc26e2cb882a0e44fd9b2a1b0421b1a0e68))
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.15 ([#2229](https://github.com/wppconnect-team/wppconnect/issues/2229)) ([6293695](https://github.com/wppconnect-team/wppconnect/commit/6293695c27cc16d0cfc7ebc950c463431f773a49))
+- Fixed error on checkNumberStatus ([#2225](https://github.com/wppconnect-team/wppconnect/issues/2225)) ([11210b3](https://github.com/wppconnect-team/wppconnect/commit/11210b3d0aa0386c6bd1d447d7bd5d9cf9ee8ef3))
+- Improovment send sticker messages (close [#2150](https://github.com/wppconnect-team/wppconnect/issues/2150)) ([d085726](https://github.com/wppconnect-team/wppconnect/commit/d085726009ba45b0fad73cf3c686863a749be7c9))
+
+### Features
+
+- Added type definitions for incoming calls ([#2211](https://github.com/wppconnect-team/wppconnect/issues/2211)) ([b88c9db](https://github.com/wppconnect-team/wppconnect/commit/b88c9dba88c8f11846e9a2ac4ad1bc11a19630c6))
+
+## [1.32.1](https://github.com/wppconnect-team/wppconnect/compare/v1.32.0...v1.32.1) (2024-06-17)
+
+### Bug Fixes
+
+- Fixed emitting events ([95e934d](https://github.com/wppconnect-team/wppconnect/commit/95e934d207fdcfbd624400a630df6634f252a9f0))
+
+# [1.32.0](https://github.com/wppconnect-team/wppconnect/compare/v1.31.1...v1.32.0) (2024-06-12)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.5.0 ([#2219](https://github.com/wppconnect-team/wppconnect/issues/2219)) ([b83f1dd](https://github.com/wppconnect-team/wppconnect/commit/b83f1dd8cd31113eb6f782f8a0bbbefb32340e58))
+- Fixed WAPI is not defined ([#2215](https://github.com/wppconnect-team/wppconnect/issues/2215)) (close [#2206](https://github.com/wppconnect-team/wppconnect/issues/2206) ([2962aac](https://github.com/wppconnect-team/wppconnect/commit/2962aac57b110e8951140e4873a7485f47714816))
+- Improovment whatsappVersion to 2.3000.10139x ([d246c58](https://github.com/wppconnect-team/wppconnect/commit/d246c58b66c7afec2b298e39a7340c829512b8b9))
+
+## [1.31.1](https://github.com/wppconnect-team/wppconnect/compare/v1.31.0...v1.31.1) (2024-06-12)
 
 ### Bug Fixes
 
 - Downgrade whatsappVersion to 2.2413.x ([22ca707](https://github.com/wppconnect-team/wppconnect/commit/22ca707c17a66441a4c19098d238899992a7c4bc))
+- Fixed get profile pic for groups (close wppconnect-server[#1644](https://github.com/wppconnect-team/wppconnect/issues/1644)) ([04fe04a](https://github.com/wppconnect-team/wppconnect/commit/04fe04ae0e0c4675c38a87f0dd26c5400198baf5))
+- Fixed options in send video-image status (close [#1787](https://github.com/wppconnect-team/wppconnect/issues/1787)) ([e8ddd5a](https://github.com/wppconnect-team/wppconnect/commit/e8ddd5a7c8e9998c31ad57184c9f5df0e825a0b7))
+- Upgrade whatsappVersion to 2.3000.1014014368-alpha ([e0b10dd](https://github.com/wppconnect-team/wppconnect/commit/e0b10dd4f71ae702c38ebfeefcd9919e222f36f2))
 
-# 1.31.0 (2024-06-10)
+# [1.31.0](https://github.com/wppconnect-team/wppconnect/compare/v1.30.3...v1.31.0) (2024-06-10)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^3.2.6 ([0ab9566](https://github.com/wppconnect-team/wppconnect/commit/0ab956636bb6a7cde59e9573e4760a09547a85e1))
 - **deps:** update dependency @wppconnect/wa-js to ^3.3.1 ([#2205](https://github.com/wppconnect-team/wppconnect/issues/2205)) ([89c3298](https://github.com/wppconnect-team/wppconnect/commit/89c3298209aed64e68fa28a9bd2102f1ae366d31))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.162 ([1954f4c](https://github.com/wppconnect-team/wppconnect/commit/1954f4c8d759b9a5ebd8ffb2a60f519082366a24))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.196 ([5fd34c2](https://github.com/wppconnect-team/wppconnect/commit/5fd34c2b7f15a78ed4fe9a09ab2e2fa3e4b9cc85))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.213 ([18aedd8](https://github.com/wppconnect-team/wppconnect/commit/18aedd8d91e36b77382157d365599861e640ab45))
+- Fixed checkNumberStatus function ([9f6c595](https://github.com/wppconnect-team/wppconnect/commit/9f6c5957e3a630eb82907ef72f7605077fc2f434))
+- Fixed error when accessing message body during notifications ([#2196](https://github.com/wppconnect-team/wppconnect/issues/2196)) ([ca44bba](https://github.com/wppconnect-team/wppconnect/commit/ca44bbab7b3151847974ddab2ee0ae5403d1f97c))
+- Fixed funding.yml ([268be6e](https://github.com/wppconnect-team/wppconnect/commit/268be6ec3c12dcef332aa0b6f1fb12d36e04d250))
+- Fixed Perfil not defined in WAPI ([2e2da93](https://github.com/wppconnect-team/wppconnect/commit/2e2da93902721b3461254e9484f34b2619de0e29))
+- Fixed start project without session name (close [#2194](https://github.com/wppconnect-team/wppconnect/issues/2194)) ([0da3d60](https://github.com/wppconnect-team/wppconnect/commit/0da3d602e3145a22e7d890e67023007dcb72e36e))
+- Upgrade whatsappVersion for 2.3000.1013232587-alpha ([6a78b11](https://github.com/wppconnect-team/wppconnect/commit/6a78b11acd8ab2c1fed97616681cc29939aa57ea))
 
-## 1.30.3 (2024-05-03)
+### Features
+
+- Added support to send mentionedList in images ([#2172](https://github.com/wppconnect-team/wppconnect/issues/2172)) ([8fa8f9d](https://github.com/wppconnect-team/wppconnect/commit/8fa8f9d4e2222a4d5d320a48ae976f541a89ad2f))
+
+## [1.30.3](https://github.com/wppconnect-team/wppconnect/compare/v1.30.2...v1.30.3) (2024-05-03)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^3.2.2 ([#2163](https://github.com/wppconnect-team/wppconnect/issues/2163)) ([aabe6b4](https://github.com/wppconnect-team/wppconnect/commit/aabe6b40fd4996fb92a40f96520c253bbdcec6e5))
 - **deps:** update dependency @wppconnect/wa-js to ^3.2.4 ([#2168](https://github.com/wppconnect-team/wppconnect/issues/2168)) ([df59aec](https://github.com/wppconnect-team/wppconnect/commit/df59aecc61415f6163dcd9e1ab79ebb0c9b8402f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.105 ([#2161](https://github.com/wppconnect-team/wppconnect/issues/2161)) ([21b5f07](https://github.com/wppconnect-team/wppconnect/commit/21b5f078c9c0be4a65df8137cfa19edfc7d4a8c4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.123 ([#2169](https://github.com/wppconnect-team/wppconnect/issues/2169)) ([70b758c](https://github.com/wppconnect-team/wppconnect/commit/70b758c3a94c744bb593b01a352c1451051a88e2))
 
-## 1.30.2 (2024-04-25)
+## [1.30.2](https://github.com/wppconnect-team/wppconnect/compare/v1.30.1...v1.30.2) (2024-04-25)
 
 ### Bug Fixes
 
+- Bypass content-security-policy errors ([#2110](https://github.com/wppconnect-team/wppconnect/issues/2110)) ([0699749](https://github.com/wppconnect-team/wppconnect/commit/069974927cffed19022140d12ad63472cd9c2031))
+- **deps:** update dependency @wppconnect/wa-js to ^3.0.1 ([#2114](https://github.com/wppconnect-team/wppconnect/issues/2114)) ([ad60722](https://github.com/wppconnect-team/wppconnect/commit/ad6072291366e9b06b26b6527bb60d7e315984b2))
+- **deps:** update dependency @wppconnect/wa-js to ^3.1.1 ([b955fd0](https://github.com/wppconnect-team/wppconnect/commit/b955fd068ca5411e344c1e9136ef37f58ef4f52e))
+- **deps:** update dependency @wppconnect/wa-version to ^1.3.11 ([5004254](https://github.com/wppconnect-team/wppconnect/commit/5004254c32ddeb204d5ca483a871fbaea5c192ea))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.28 ([a07a9ed](https://github.com/wppconnect-team/wppconnect/commit/a07a9ed47e30b40e0eb32b54ee72d789bd8d42b8))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.6 ([0166bef](https://github.com/wppconnect-team/wppconnect/commit/0166bef24aaa99e432a6bee767a06907be5825c0))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.61 ([4ff4204](https://github.com/wppconnect-team/wppconnect/commit/4ff4204c1c83bb27b79f6ee46ca8efaefe12a422))
+- **deps:** update dependency @wppconnect/wa-version to ^1.4.8 ([#2117](https://github.com/wppconnect-team/wppconnect/issues/2117)) ([c8623e6](https://github.com/wppconnect-team/wppconnect/commit/c8623e6e518d07a46d445cd78f3766ffcad4f52c))
+- Fixed main-frame crash ([#2091](https://github.com/wppconnect-team/wppconnect/issues/2091)) (close [#2052](https://github.com/wppconnect-team/wppconnect/issues/2052), close [#1954](https://github.com/wppconnect-team/wppconnect/issues/1954)) ([6177c53](https://github.com/wppconnect-team/wppconnect/commit/6177c53061ab89c8b0b8debfefa8a09c4ffefee6))
+- Upgrade default whatsapp version ([#2141](https://github.com/wppconnect-team/wppconnect/issues/2141)) ([2772527](https://github.com/wppconnect-team/wppconnect/commit/277252730512f1f59130e27a55b7645bdc67b737))
 - Upgrade whatsappVersion ([b8b1ec7](https://github.com/wppconnect-team/wppconnect/commit/b8b1ec75e5b2926e96fe83f21921f49824eea9cc))
 
-## <small>1.30.1 (2024-03-11)</small>
-
-- fix: Fixed login by qr code ([5ebd5f5](https://github.com/wppconnect-team/wppconnect/commit/5ebd5f5))
-
-## 1.30.0 (2024-03-10)
-
-- fix(deps): update dependency @wppconnect/wa-js to v3 (#2103) ([3f5a658](https://github.com/wppconnect-team/wppconnect/commit/3f5a658)), closes [#2103](https://github.com/wppconnect-team/wppconnect/issues/2103)
-
-## 1.29.0 (2024-01-25)
-
-- [FIX] version whatsapp web ([716cd97](https://github.com/wppconnect-team/wppconnect/commit/716cd97))
-
-## <small>1.28.4 (2023-12-25)</small>
-
-- fix: Remove unnecessary code for close instance (close #1835) ([43f2a9b](https://github.com/wppconnect-team/wppconnect/commit/43f2a9b)), closes [#1835](https://github.com/wppconnect-team/wppconnect/issues/1835)
-
-## <small>1.28.3 (2023-11-15)</small>
-
-- feat: Added client.getCommonGroups function ([194c898](https://github.com/wppconnect-team/wppconnect/commit/194c898))
-
-## <small>1.28.2 (2023-11-04)</small>
-
-- chore: Update release-it ([4869dc8](https://github.com/wppconnect-team/wppconnect/commit/4869dc8))
-
-## <small>1.28.1 (2023-11-01)</small>
-
-- fix : update version whatsappVersion 2.2347.x ([6fe090a](https://github.com/wppconnect-team/wppconnect/commit/6fe090a))
-
-# 1.28.0 (2023-08-16)
-
-## 1.27.3 (2023-06-14)
+## [1.30.1](https://github.com/wppconnect-team/wppconnect/compare/v1.30.0...v1.30.1) (2024-03-11)
 
 ### Bug Fixes
 
+- Fixed login by qr code ([5ebd5f5](https://github.com/wppconnect-team/wppconnect/commit/5ebd5f5f140909d0e05984173190dc375a79ed2b))
+
+# [1.30.0](https://github.com/wppconnect-team/wppconnect/compare/v1.29.0...v1.30.0) (2024-03-10)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to v3 ([#2103](https://github.com/wppconnect-team/wppconnect/issues/2103)) ([3f5a658](https://github.com/wppconnect-team/wppconnect/commit/3f5a6581f9c6ba241a3215ef0d71cda9448d16af))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.216 ([a72e2c8](https://github.com/wppconnect-team/wppconnect/commit/a72e2c8b7e2e8f3d85a6babddef996e04e12d918))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.228 ([affc3ac](https://github.com/wppconnect-team/wppconnect/commit/affc3ac5415339eab0095654ac986d2863f5b99d))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.237 ([149c6f6](https://github.com/wppconnect-team/wppconnect/commit/149c6f60bef205f787687c9e57892ddec6b88ff6))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.246 ([a15c28e](https://github.com/wppconnect-team/wppconnect/commit/a15c28e2ec043978c1c9118b659654e92f98be53))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.254 ([67796d8](https://github.com/wppconnect-team/wppconnect/commit/67796d89bdf071c1f1e879d743f066ab7492dc65))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.263 ([#2086](https://github.com/wppconnect-team/wppconnect/issues/2086)) ([a06a786](https://github.com/wppconnect-team/wppconnect/commit/a06a7863654a18776aa92380f6b69256629c2439))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.267 ([#2100](https://github.com/wppconnect-team/wppconnect/issues/2100)) ([7116d09](https://github.com/wppconnect-team/wppconnect/commit/7116d09b45e91c03d4cd129afe1d9edf2f84a8c0))
+- Fixed removepartcipant return (close [#1709](https://github.com/wppconnect-team/wppconnect/issues/1709)) ([#2094](https://github.com/wppconnect-team/wppconnect/issues/2094)) ([79a10c0](https://github.com/wppconnect-team/wppconnect/commit/79a10c0ad235188cd5c8e29154755a5a66d42704))
+- Fixed start with new version of puppetter (close [#2079](https://github.com/wppconnect-team/wppconnect/issues/2079) ([#2093](https://github.com/wppconnect-team/wppconnect/issues/2093)) ([3c9d191](https://github.com/wppconnect-team/wppconnect/commit/3c9d1917fa7272fa36d02eca1597cb13adb96181))
+- Improovments on default browser args (close [#2048](https://github.com/wppconnect-team/wppconnect/issues/2048)) ([ca22e22](https://github.com/wppconnect-team/wppconnect/commit/ca22e228a83e77f774ac1e38ac2389d1d0c48150))
+
+### Features
+
+- Added login by code ([#2097](https://github.com/wppconnect-team/wppconnect/issues/2097)) (close [#1921](https://github.com/wppconnect-team/wppconnect/issues/1921)) ([4f38303](https://github.com/wppconnect-team/wppconnect/commit/4f38303b34e6d1334c07468efdd0695b36ecc1ab))
+- Added support to options in send status ([#2096](https://github.com/wppconnect-team/wppconnect/issues/2096)) ([1aa0735](https://github.com/wppconnect-team/wppconnect/commit/1aa07354d077cc254e2b6cb9680fbb7422817666))
+
+# [1.29.0](https://github.com/wppconnect-team/wppconnect/compare/v1.28.4...v1.29.0) (2024-01-25)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.180 ([e5b2690](https://github.com/wppconnect-team/wppconnect/commit/e5b2690ba17e97f876b3e84b8cf76b665b9b08f9))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.182 ([02dd778](https://github.com/wppconnect-team/wppconnect/commit/02dd7785c2874fb3a89f8224372044fddb3d0636))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.187 ([fec4aff](https://github.com/wppconnect-team/wppconnect/commit/fec4aff6f0e7a67b63479d865079978cd4b3dd65))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.189 ([e8330dd](https://github.com/wppconnect-team/wppconnect/commit/e8330ddc6efa02ad2ab40e279553a820d93c3dd4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.195 ([0edbadc](https://github.com/wppconnect-team/wppconnect/commit/0edbadca77336299dc4c29c110e0f36e5e45a34e))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.199 ([#2030](https://github.com/wppconnect-team/wppconnect/issues/2030)) ([af9acec](https://github.com/wppconnect-team/wppconnect/commit/af9acec2631eecaf2591c42865c5a57c047aece9))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.203 ([33bf173](https://github.com/wppconnect-team/wppconnect/commit/33bf1730be1d6580d7fc98a1b1e157fe3a9e57a2))
+
+### Features
+
+- add poll_creation to message types ([#2016](https://github.com/wppconnect-team/wppconnect/issues/2016)) ([eb3143f](https://github.com/wppconnect-team/wppconnect/commit/eb3143fbd300139e1de117b534ff7584c5c56ad6))
+
+## [1.28.4](https://github.com/wppconnect-team/wppconnect/compare/v1.28.3...v1.28.4) (2023-12-25)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.28.1 ([2900e10](https://github.com/wppconnect-team/wppconnect/commit/2900e10b1d4940773cbf932fcde98c09a6311095))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.150 ([b7087c4](https://github.com/wppconnect-team/wppconnect/commit/b7087c4e5a590023519dba08e9ba2cfb5483e664))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.153 ([1fae9e0](https://github.com/wppconnect-team/wppconnect/commit/1fae9e0cd5512776900c93ae288d58dec26cf38e))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.155 ([5f4da04](https://github.com/wppconnect-team/wppconnect/commit/5f4da04d4d2be2ffa867affcc73902d8b283a9cd))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.159 ([d99605d](https://github.com/wppconnect-team/wppconnect/commit/d99605ddc6914d3e6af25ff0e980dc7a2c23a544))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.160 ([00e6556](https://github.com/wppconnect-team/wppconnect/commit/00e6556d48b1b01c078e859660749da2fc32e882))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.164 ([#1981](https://github.com/wppconnect-team/wppconnect/issues/1981)) ([0ca543a](https://github.com/wppconnect-team/wppconnect/commit/0ca543a87dc60d21ef382af8c2465e7e49612ef3))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.169 ([334831e](https://github.com/wppconnect-team/wppconnect/commit/334831e43dce9354859d2307599458ee5728b0be))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.172 ([52e9b31](https://github.com/wppconnect-team/wppconnect/commit/52e9b31f3a3654185a5fe07a4708122a98caaa2f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.174 ([#1999](https://github.com/wppconnect-team/wppconnect/issues/1999)) ([fdf2dfe](https://github.com/wppconnect-team/wppconnect/commit/fdf2dfef8fcdcddd195e56f848fa624f3f000ea3))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.176 ([35f4a7a](https://github.com/wppconnect-team/wppconnect/commit/35f4a7ad03ceb38ef18dcfc6c9e0a19ec03f7d22))
+- Fixed client.forwardMessage ([b8e13e2](https://github.com/wppconnect-team/wppconnect/commit/b8e13e220c5de082ec2fd61e032f55aac947d01a))
+- Remove unnecessary code for close instance (close [#1835](https://github.com/wppconnect-team/wppconnect/issues/1835)) ([43f2a9b](https://github.com/wppconnect-team/wppconnect/commit/43f2a9b3cb4d1489c329fc98bdb1cc7e4e362ea2))
+
+### Features
+
+- Added client.getPID function (close [#1425](https://github.com/wppconnect-team/wppconnect/issues/1425)) ([4912734](https://github.com/wppconnect-team/wppconnect/commit/4912734b8ff21cd923a9f3c9581eab05235c4405))
+
+## [1.28.3](https://github.com/wppconnect-team/wppconnect/compare/v1.28.2...v1.28.3) (2023-11-15)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.141 ([83dc843](https://github.com/wppconnect-team/wppconnect/commit/83dc843f980c0357eac03b5f47d42b3450b10804))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.148 ([#1937](https://github.com/wppconnect-team/wppconnect/issues/1937)) ([dab2bd4](https://github.com/wppconnect-team/wppconnect/commit/dab2bd4378e2056db9dfa6194caf609ed48dd9f4))
+
+### Features
+
+- Added client.editMessage function ([#1927](https://github.com/wppconnect-team/wppconnect/issues/1927)) ([394ef17](https://github.com/wppconnect-team/wppconnect/commit/394ef1741675c34a1e839d3994be056995e4fb55))
+- Added client.getCommonGroups function ([194c898](https://github.com/wppconnect-team/wppconnect/commit/194c898d4a444efac27873c21f6f8eb5851313a9))
+- Added client.sendOrderMessage ([9a7f52f](https://github.com/wppconnect-team/wppconnect/commit/9a7f52f2c2ed8d8e155d72c0c92ea28940d6b9f4))
+- Added cliente.getOrder function ([76cd217](https://github.com/wppconnect-team/wppconnect/commit/76cd217756acc4c345cab118d19a16870a14f142))
+- Added newsletter functions ([#1893](https://github.com/wppconnect-team/wppconnect/issues/1893)) ([64ed54a](https://github.com/wppconnect-team/wppconnect/commit/64ed54a3a5c14502e162cb20a02f4f660ce7f49a))
+- Added onOrderStatusUpdate event ([149cd83](https://github.com/wppconnect-team/wppconnect/commit/149cd83d1a3a641671190ac06e87faedff96d7ac))
+
+## [1.28.2](https://github.com/wppconnect-team/wppconnect/compare/v1.28.1...v1.28.2) (2023-11-04)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.135 ([b1bfb09](https://github.com/wppconnect-team/wppconnect/commit/b1bfb09ea483468cda09b522fd15d67f8d704ab6))
+- Fixed build and start mistakes (close [#1911](https://github.com/wppconnect-team/wppconnect/issues/1911)) ([222c1d9](https://github.com/wppconnect-team/wppconnect/commit/222c1d91cded6152ee6fa84a742c0e1254b0942f))
+
+## [1.28.1](https://github.com/wppconnect-team/wppconnect/compare/v1.28.0...v1.28.1) (2023-11-01)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.25.0 ([#1813](https://github.com/wppconnect-team/wppconnect/issues/1813)) ([86d17c7](https://github.com/wppconnect-team/wppconnect/commit/86d17c7d92b0318fccd42b0513040029f09b3d8a))
+- **deps:** update dependency @wppconnect/wa-js to ^2.26.0 ([#1821](https://github.com/wppconnect-team/wppconnect/issues/1821)) ([7f7a2b0](https://github.com/wppconnect-team/wppconnect/commit/7f7a2b08372bb94f3f5dccaa129542787c2acf73))
+- **deps:** update dependency @wppconnect/wa-js to ^2.26.1 ([2c1d667](https://github.com/wppconnect-team/wppconnect/commit/2c1d667011c6ddb225ce4a9fc0aa60c26bd6713d))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.101 ([f4c8dfe](https://github.com/wppconnect-team/wppconnect/commit/f4c8dfef5f772c96f6bba15a5e226c974c45b4b2))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.110 ([60ff8c3](https://github.com/wppconnect-team/wppconnect/commit/60ff8c35d89b3972f21dedd78eb71b802e3df970))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.115 ([a374d4e](https://github.com/wppconnect-team/wppconnect/commit/a374d4e3f0252d96d3eb749befcaad28a22e1e0b))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.122 ([ed79ee4](https://github.com/wppconnect-team/wppconnect/commit/ed79ee49098708f8bca87e8510e0d62638fcab54))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.123 ([1b8c3a1](https://github.com/wppconnect-team/wppconnect/commit/1b8c3a1ce848871fec4a4fda4fab1c0a3ab80fa8))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.129 ([60e6791](https://github.com/wppconnect-team/wppconnect/commit/60e679117b42ca72e9c5b24b98bcb742f9b3749a))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.82 ([89f5c39](https://github.com/wppconnect-team/wppconnect/commit/89f5c392a0fb5bcef7a61723445055c692df8729))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.86 ([#1812](https://github.com/wppconnect-team/wppconnect/issues/1812)) ([28a861c](https://github.com/wppconnect-team/wppconnect/commit/28a861cc16229f9b2b9dc7e76407932376b855e4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.89 ([7b5383d](https://github.com/wppconnect-team/wppconnect/commit/7b5383d5c218a404e0ea5d17fc53b174e5ce6b52))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.90 ([96ae45a](https://github.com/wppconnect-team/wppconnect/commit/96ae45a3882074c93b41d18133fc668f919fc12d))
+- Fixed version default for 2.2346 ([#1891](https://github.com/wppconnect-team/wppconnect/issues/1891)) ([76ec244](https://github.com/wppconnect-team/wppconnect/commit/76ec244ed718defe92c901c1c9352209c1adb716))
+
+### Features
+
+- Added sendTextStatus functions ([#1890](https://github.com/wppconnect-team/wppconnect/issues/1890)) ([12bf974](https://github.com/wppconnect-team/wppconnect/commit/12bf974581083b636c86713d18d31f2ada4751c1))
+- Added deleteOldChats functions ([#1888](https://github.com/wppconnect-team/wppconnect/issues/1888)) ([4cdb5d3](https://github.com/wppconnect-team/wppconnect/commit/4cdb5d35959a3f567f095c904bc4d77f954f2bdc))
+
+# [1.28.0](https://github.com/wppconnect-team/wppconnect/compare/v1.27.3...v1.28.0) (2023-08-16)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.4 ([2074f2f](https://github.com/wppconnect-team/wppconnect/commit/2074f2fa61b05aaf53baba4dda04a0215c05079a))
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.5 ([7f4d8a7](https://github.com/wppconnect-team/wppconnect/commit/7f4d8a72604dc31c7e20094d911afc8c1d697929))
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.6 ([54e5b63](https://github.com/wppconnect-team/wppconnect/commit/54e5b6331c843bae50e17c629046c09508852ef7))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.53 ([5eded3c](https://github.com/wppconnect-team/wppconnect/commit/5eded3cdf76d340da27d80038064494f1397d422))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.60 ([8a78f47](https://github.com/wppconnect-team/wppconnect/commit/8a78f47618c3e91348f7104d196f1179657fe9dd))
+
+### Features
+
+- Update the minimal WhatsApp to 2.2331.x ([f9ac1ea](https://github.com/wppconnect-team/wppconnect/commit/f9ac1ea1ab866b72b0d34e61b7d88615b2d4f3ef))
+
+## [1.27.3](https://github.com/wppconnect-team/wppconnect/compare/v1.27.2...v1.27.3) (2023-06-14)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.3 ([#1728](https://github.com/wppconnect-team/wppconnect/issues/1728)) ([bd761d8](https://github.com/wppconnect-team/wppconnect/commit/bd761d8ae35f19fa85673fe06b60edfe863722ca))
 - **deps:** update dependency @wppconnect/wa-version to ^1.2.49 ([#1729](https://github.com/wppconnect-team/wppconnect/issues/1729)) ([bcb26ce](https://github.com/wppconnect-team/wppconnect/commit/bcb26cea7f5b02f1ba28b2a8311a586832b5659c))
 
-## 1.27.2 (2023-06-05)
+## [1.27.2](https://github.com/wppconnect-team/wppconnect/compare/v1.27.1...v1.27.2) (2023-06-05)
 
-## 1.27.1 (2023-06-04)
+## [1.27.1](https://github.com/wppconnect-team/wppconnect/compare/v1.27.0...v1.27.1) (2023-06-04)
 
 ### Bug Fixes
 
 - Reverting to previous fix as a temporary workaround ([#1718](https://github.com/wppconnect-team/wppconnect/issues/1718)) ([a0375b6](https://github.com/wppconnect-team/wppconnect/commit/a0375b6086507882600b4d24e12be23add1c4e29))
 
-# 1.27.0 (2023-06-02)
+# [1.27.0](https://github.com/wppconnect-team/wppconnect/compare/v1.26.0...v1.27.0) (2023-06-02)
 
 ### Bug Fixes
 
+- DEPRECATED getAllChatsWithMessages getAllChats & getAllGroups ([1ad6445](https://github.com/wppconnect-team/wppconnect/commit/1ad6445b2078c4e3d1a8f11940c6adc3471e30e6))
 - **deps:** update dependency @wppconnect/wa-version to ^1.2.44 ([#1716](https://github.com/wppconnect-team/wppconnect/issues/1716)) ([a62cb18](https://github.com/wppconnect-team/wppconnect/commit/a62cb188f1ee0f0dba8c49ab9638c943486835e7))
 
-# 1.26.0 (2023-06-01)
+### Features
 
-# 1.25.0 (2023-05-30)
+- Added community functions ([3d3debf](https://github.com/wppconnect-team/wppconnect/commit/3d3debfb06ef93d6eec52feee9c5a5c0eb02c93f))
+- Added getGroupSizeLimit function (close [#1365](https://github.com/wppconnect-team/wppconnect/issues/1365)) ([8329e70](https://github.com/wppconnect-team/wppconnect/commit/8329e704c01fc30c331e74dabf9509022440f0df))
+- Added listChats function ([e145688](https://github.com/wppconnect-team/wppconnect/commit/e1456880ac83d8292ee9cb2d199b7ea1c39b7caa))
+
+# [1.26.0](https://github.com/wppconnect-team/wppconnect/compare/v1.25.0...v1.26.0) (2023-06-01)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.43 ([#1710](https://github.com/wppconnect-team/wppconnect/issues/1710)) ([397f7cb](https://github.com/wppconnect-team/wppconnect/commit/397f7cb1816f971149df185c6cd5a52f72e738bf))
+- Fixed messageId error ([60ce18f](https://github.com/wppconnect-team/wppconnect/commit/60ce18f61aa3163d546ab22255786bf3d539c08b))
+- Fixed typedoc ([a7185c0](https://github.com/wppconnect-team/wppconnect/commit/a7185c01492c4cf27ac5994b51e5ec794cd549d5))
+
+### Features
+
+- Added takeScreenshot function ([2d676f5](https://github.com/wppconnect-team/wppconnect/commit/2d676f51c6dfd7ba0a9e830e1b45198ccbe8f895))
+
+# [1.25.0](https://github.com/wppconnect-team/wppconnect/compare/v1.24.0...v1.25.0) (2023-05-30)
+
+### Bug Fixes
+
+- Changed headless to new chrome mode ([88625ba](https://github.com/wppconnect-team/wppconnect/commit/88625ba07c50ce531fabfd9831fb1159c5fbec6c))
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.0 ([fd0b379](https://github.com/wppconnect-team/wppconnect/commit/fd0b379da94670e024abdfa3748156ab358f028b))
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.1 ([037b31c](https://github.com/wppconnect-team/wppconnect/commit/037b31c91503ab769a60c09a62b13776ee7a867a))
+- **deps:** update dependency @wppconnect/wa-js to ^2.24.2 ([45450e9](https://github.com/wppconnect-team/wppconnect/commit/45450e9bd1f8bbe03a8d5f68df3f6ea519354a6c))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.29 ([96ad849](https://github.com/wppconnect-team/wppconnect/commit/96ad8498fa165f278e1ca596a86f1d4f73e1570f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.33 ([ce1fcdb](https://github.com/wppconnect-team/wppconnect/commit/ce1fcdbe13db74d9226c8d72a94297a5ee1bd15b))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.35 ([0cecfe4](https://github.com/wppconnect-team/wppconnect/commit/0cecfe48cb8ce461e556e26df5f4a03be24b540a))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.41 ([6959612](https://github.com/wppconnect-team/wppconnect/commit/69596120cbf2c30f858a7d7104e09710700dbd44))
 - **deps:** update dependency @wppconnect/wa-version to ^1.2.42 ([#1700](https://github.com/wppconnect-team/wppconnect/issues/1700)) ([1c07a4b](https://github.com/wppconnect-team/wppconnect/commit/1c07a4b410037dbb748749e9faefde0fc4f04903))
+- Improovment sendPtt with pre messageId (close [#1292](https://github.com/wppconnect-team/wppconnect/issues/1292)) ([675701c](https://github.com/wppconnect-team/wppconnect/commit/675701cb866a7c9bdea1dd85fbf80abd5b87efa1))
 
-# 1.24.0 (2023-04-29)
+### Features
 
-## 1.23.2 (2023-04-03)
+- Added approveGroupMembershipRequest function ([7b0e0e6](https://github.com/wppconnect-team/wppconnect/commit/7b0e0e6ce8c6e98e8ab57fc4df84252048d5740e))
+- Added client.isOnline function ([c2a9f23](https://github.com/wppconnect-team/wppconnect/commit/c2a9f2393b4b7c2bb5c1f08f4cb75066a097edf9))
+- Added client.joinWebBeta function ([dcffbcd](https://github.com/wppconnect-team/wppconnect/commit/dcffbcda74075c8758095398553e4a2964d6d53d))
+- Added getGroupMembershipRequests function ([bec03b1](https://github.com/wppconnect-team/wppconnect/commit/bec03b1ec8f33253bd6abc99f2cc628ff2909a0f))
+- Added onUpdateLabel event ([b093c53](https://github.com/wppconnect-team/wppconnect/commit/b093c53f8b914576bd0199795263b4a1ebaa0ef2))
+- Added rejectGroupMembershipRequest function ([9684395](https://github.com/wppconnect-team/wppconnect/commit/968439515e4f5dfbf9f220817c08f213553019ed))
+- Added setLimit function ([09d9e0f](https://github.com/wppconnect-team/wppconnect/commit/09d9e0f730ddfcf4af2d45ff0bfc99f2cc4a4130))
 
-## 1.23.1 (2023-03-25)
+# [1.24.0](https://github.com/wppconnect-team/wppconnect/compare/v1.23.2...v1.24.0) (2023-04-29)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^2.23.3 ([eeeb0cf](https://github.com/wppconnect-team/wppconnect/commit/eeeb0cf4d137152405a6d84c59529198aeea7062))
+- **deps:** update dependency @wppconnect/wa-js to ^2.23.5 ([#1664](https://github.com/wppconnect-team/wppconnect/issues/1664)) ([be1b9aa](https://github.com/wppconnect-team/wppconnect/commit/be1b9aa6a85d7133768a682afb305db2bde82a8f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.15 ([3c4b2ed](https://github.com/wppconnect-team/wppconnect/commit/3c4b2ed0542dae3afdc0fa7b61a835194234a972))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.16 ([27863c2](https://github.com/wppconnect-team/wppconnect/commit/27863c2e7726d105d85c5ec68d61af4e5fb172c5))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.21 ([b868f0a](https://github.com/wppconnect-team/wppconnect/commit/b868f0a4be31e19fcad72a8521d3883a66b48b2d))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.27 ([2e98bbf](https://github.com/wppconnect-team/wppconnect/commit/2e98bbf587ff97aff694371aa9896cc83803ac85))
+
+### Features
+
+- Added client.getActiveChat ([9d1c959](https://github.com/wppconnect-team/wppconnect/commit/9d1c9595a331aaf510df23ee2c94098f6663fed7))
+- Added client.removeMyProfilePicture ([9d0f239](https://github.com/wppconnect-team/wppconnect/commit/9d0f239819430ba30811fa69606663f4110752b5))
+- Added new functions to check conn ([0b5e28b](https://github.com/wppconnect-team/wppconnect/commit/0b5e28b98275afbf6a164480b5d68cba9b0a8572))
+- Added new functions to groups ([01cb169](https://github.com/wppconnect-team/wppconnect/commit/01cb1694d2fd904342fdb4f39f7c99df1799546d))
+
+## [1.23.2](https://github.com/wppconnect-team/wppconnect/compare/v1.23.1...v1.23.2) (2023-04-03)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.23.1 ([#1622](https://github.com/wppconnect-team/wppconnect/issues/1622)) ([7b65a47](https://github.com/wppconnect-team/wppconnect/commit/7b65a47f169a31a0da999f99dee542f1a07d1149))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.12 ([b06ab75](https://github.com/wppconnect-team/wppconnect/commit/b06ab75199952c2d3dd064ec26f9cd9c650b3de4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.13 ([#1617](https://github.com/wppconnect-team/wppconnect/issues/1617)) ([6df700d](https://github.com/wppconnect-team/wppconnect/commit/6df700d16e43b7200e0c9ccafd47fddd78de0454))
+
+## [1.23.1](https://github.com/wppconnect-team/wppconnect/compare/v1.23.0...v1.23.1) (2023-03-25)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.22.2 ([09e5cfa](https://github.com/wppconnect-team/wppconnect/commit/09e5cfadf59e1353c7e1f34a744bdb6cfaf04314))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.10 ([1873019](https://github.com/wppconnect-team/wppconnect/commit/187301947859ad782323b11de3a262ab4c02402c))
 - Fixed multiple inChat emit events ([#1598](https://github.com/wppconnect-team/wppconnect/issues/1598)) ([4900765](https://github.com/wppconnect-team/wppconnect/commit/4900765f20a7c879e597ce01ebcce05bf244006b))
 
-# 1.23.0 (2023-03-12)
+# [1.23.0](https://github.com/wppconnect-team/wppconnect/compare/v1.22.0...v1.23.0) (2023-03-12)
+
+- fix!: Removed token store in favor of userDataDir ([933e5d7](https://github.com/wppconnect-team/wppconnect/commit/933e5d71eb4242d8901ff83769340b40cb1d9fca))
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^2.22.0 ([#1574](https://github.com/wppconnect-team/wppconnect/issues/1574)) ([20a4140](https://github.com/wppconnect-team/wppconnect/commit/20a4140237f3140d79d3268ff2c7f8c90bd00645))
+- **deps:** update dependency @wppconnect/wa-version to ^1.2.5 ([#1575](https://github.com/wppconnect-team/wppconnect/issues/1575)) ([41f073c](https://github.com/wppconnect-team/wppconnect/commit/41f073cd950f6855dd9d72e871750d6270089044))
+- Fixed rejectCall method ([194ed96](https://github.com/wppconnect-team/wppconnect/commit/194ed968c8b2aa808c51489feedb3439e04afbae))
 - Reduced the number of log for events ([5b39646](https://github.com/wppconnect-team/wppconnect/commit/5b396467c594396741f61495da1c23bac19c8c94))
 
-# 1.22.0 (2023-02-19)
+### Features
+
+- Refatored create code for stability ([10b2782](https://github.com/wppconnect-team/wppconnect/commit/10b27823c266201aef4723dff268a9694ca6aae7))
+
+### BREAKING CHANGES
+
+- Removed usage of token store to priorize userDataDir
+
+# [1.22.0](https://github.com/wppconnect-team/wppconnect/compare/v1.21.0...v1.22.0) (2023-02-19)
+
+### Bug Fixes
+
+- Changed the default log level to silly ([caf7275](https://github.com/wppconnect-team/wppconnect/commit/caf727532835a6a5b3783ba0c6ea1187f83f0a28))
+- **deps:** update dependency @wppconnect/wa-js to ^2.19.1 ([4cf84d5](https://github.com/wppconnect-team/wppconnect/commit/4cf84d56808c1fa079d0f23a2044964bfd3e60d4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.248 ([a20dad1](https://github.com/wppconnect-team/wppconnect/commit/a20dad163baabeb7e64010d25dda365cd83c422a))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.250 ([01f7530](https://github.com/wppconnect-team/wppconnect/commit/01f7530abf6aba70b6f391fb41d134440582dc32))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.257 ([#1554](https://github.com/wppconnect-team/wppconnect/issues/1554)) ([3560b2f](https://github.com/wppconnect-team/wppconnect/commit/3560b2f4e93f679d50f26d28f7afa465d5c594ef))
+- Updated the minimal version of WhatsApp WEB to >= 2.2307.x ([911a141](https://github.com/wppconnect-team/wppconnect/commit/911a141eb38fd7ebd7563c7a5976a6ce93afc722))
+- Use latest version of WhatsApp web as fallback (fix [#1553](https://github.com/wppconnect-team/wppconnect/issues/1553)) ([39c5efb](https://github.com/wppconnect-team/wppconnect/commit/39c5efb691f3d53436fe1dbc621d2bc2c2b48c77))
 
 ### Features
 
 - Added deviceSyncTimeout option (close [#1551](https://github.com/wppconnect-team/wppconnect/issues/1551)) ([d4458e5](https://github.com/wppconnect-team/wppconnect/commit/d4458e5c3727b4d96e1595a6f5fa2d798a2bd69a))
 
-# 1.21.0 (2023-02-03)
+# [1.21.0](https://github.com/wppconnect-team/wppconnect/compare/v1.20.0...v1.21.0) (2023-02-03)
 
 ### Bug Fixes
 
+- add createProduct method ([a5ac010](https://github.com/wppconnect-team/wppconnect/commit/a5ac0102fafce93561e1c6114c6e75a96be5df93))
+- **deps:** update dependency @wppconnect/wa-js to ^2.18.2 ([c71ee8d](https://github.com/wppconnect-team/wppconnect/commit/c71ee8d8be135dd743a8150b054d12009c798106))
+- **deps:** update dependency @wppconnect/wa-js to ^2.18.3 ([502848a](https://github.com/wppconnect-team/wppconnect/commit/502848ab0aaaa63ab9c2875a7f05287dc7713ddb))
+- **deps:** update dependency @wppconnect/wa-js to ^2.18.4 ([#1512](https://github.com/wppconnect-team/wppconnect/issues/1512)) ([d467cc1](https://github.com/wppconnect-team/wppconnect/commit/d467cc1cdd5d8e78bdd1f997a3f06668389e61c8))
 - **deps:** update dependency @wppconnect/wa-js to ^2.19.0 ([#1531](https://github.com/wppconnect-team/wppconnect/issues/1531)) ([09626d0](https://github.com/wppconnect-team/wppconnect/commit/09626d0b4921609633b77a1fcc2a67e9882a9dc4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.214 ([88e0817](https://github.com/wppconnect-team/wppconnect/commit/88e08179c53a796718158f7958e327bc64b13bcf))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.216 ([a13fb1b](https://github.com/wppconnect-team/wppconnect/commit/a13fb1bdaa0e9c7181c62ee7e44c9d1abb38fc1a))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.217 ([242ca5d](https://github.com/wppconnect-team/wppconnect/commit/242ca5d0208498d5d1f8a505084df02f89b202e3))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.221 ([c945201](https://github.com/wppconnect-team/wppconnect/commit/c94520154575e7e35630ccbe648520ffe26f50d3))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.222 ([a172e66](https://github.com/wppconnect-team/wppconnect/commit/a172e66acfe268fb47c6dbb9115523acb3066ff8))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.225 ([2c13bfb](https://github.com/wppconnect-team/wppconnect/commit/2c13bfbbb69d6a6fd735e6a7dd1567848b85f106))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.230 ([abff1ca](https://github.com/wppconnect-team/wppconnect/commit/abff1caaaaf4363027ff5abf5ebde4b85bc6a7ce))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.239 ([b47cd3f](https://github.com/wppconnect-team/wppconnect/commit/b47cd3fd691f093c758610537362a48fb4ee3836))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.244 ([908415e](https://github.com/wppconnect-team/wppconnect/commit/908415ee11367a629362602a5921fb8f2c4b0eeb))
+- Updated the minimal version of WhatsApp WEB to >=2.2245.x ([32e5ef2](https://github.com/wppconnect-team/wppconnect/commit/32e5ef2f17ce2a9eaa82f214bde97a9cb4ed61c9))
 
-# 1.20.0 (2022-12-15)
+### Features
+
+- add create product on wppconnect api ([da1a3b9](https://github.com/wppconnect-team/wppconnect/commit/da1a3b99c1574e171f75774f686139e125866a2d))
+
+# [1.20.0](https://github.com/wppconnect-team/wppconnect/compare/v1.19.2...v1.20.0) (2022-12-15)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.18.0 ([#1468](https://github.com/wppconnect-team/wppconnect/issues/1468)) ([56e548b](https://github.com/wppconnect-team/wppconnect/commit/56e548b6a92b8496df72fd22559fef01246268b0))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.212 ([1371956](https://github.com/wppconnect-team/wppconnect/commit/13719564a38a221b1e91090b365c979f3c9ca21c))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.213 ([#1467](https://github.com/wppconnect-team/wppconnect/issues/1467)) ([c7ca0e1](https://github.com/wppconnect-team/wppconnect/commit/c7ca0e18c315b05386efe4915d259c5737d251b9))
 
 ### Features
 
 - Added getVotes and getReactions functions ([49bb58f](https://github.com/wppconnect-team/wppconnect/commit/49bb58f9c0db9271a36cea4d650857f2ddbde74a))
+- Added onPollResponse event ([15ebdfc](https://github.com/wppconnect-team/wppconnect/commit/15ebdfc9a57ac80f33f4795ca546d9a311521ee5))
 
-## 1.19.2 (2022-12-11)
-
-## 1.19.1 (2022-11-18)
+## [1.19.2](https://github.com/wppconnect-team/wppconnect/compare/v1.19.1...v1.19.2) (2022-12-11)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^2.17.0 ([965e284](https://github.com/wppconnect-team/wppconnect/commit/965e28442163f445ccdc27b618614a02c8f54ced))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.200 ([e71c429](https://github.com/wppconnect-team/wppconnect/commit/e71c429a95a8312f4620609b50cde32876f47035))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.202 ([b811474](https://github.com/wppconnect-team/wppconnect/commit/b811474a390cd1b95f3f502bbc47515fbcb11d7b))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.203 ([41aeb19](https://github.com/wppconnect-team/wppconnect/commit/41aeb1961bb7023bed7853037774dfb9d4065326))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.204 ([5df9fdd](https://github.com/wppconnect-team/wppconnect/commit/5df9fdd617be0afc9ae67bca49f24f39dc22eddd))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.208 ([#1459](https://github.com/wppconnect-team/wppconnect/issues/1459)) ([291cc96](https://github.com/wppconnect-team/wppconnect/commit/291cc96ba89d2e951c90a5403740d361bf870542))
+- Fixed Puppeteer error and undefined sendList ([#1453](https://github.com/wppconnect-team/wppconnect/issues/1453)) ([d0891fe](https://github.com/wppconnect-team/wppconnect/commit/d0891feaaadba83e84baa67bbd976d1d460a698d))
+
+## [1.19.1](https://github.com/wppconnect-team/wppconnect/compare/v1.19.0...v1.19.1) (2022-11-18)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.15.1 ([8da5082](https://github.com/wppconnect-team/wppconnect/commit/8da50820d31ffd77e1f95251c52b4791e74ce932))
+- **deps:** update dependency @wppconnect/wa-js to ^2.15.2 ([c18c547](https://github.com/wppconnect-team/wppconnect/commit/c18c547386984f0770ee8c580351de6d9071ca74))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.185 ([926f440](https://github.com/wppconnect-team/wppconnect/commit/926f4400a3c006d9d944ead3151092ec3a3fd838))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.187 ([27dcf14](https://github.com/wppconnect-team/wppconnect/commit/27dcf143aa87e88f9324dc371b8362f30d527bad))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.190 ([f819bc8](https://github.com/wppconnect-team/wppconnect/commit/f819bc8cb76e8280fb4d682ae3c491993346a2a4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.197 ([641ff35](https://github.com/wppconnect-team/wppconnect/commit/641ff35940fb954e7830295f2f9380495893bb80))
 - Fixed onMessage method (fix [#1351](https://github.com/wppconnect-team/wppconnect/issues/1351)) ([e8549a1](https://github.com/wppconnect-team/wppconnect/commit/e8549a10cf7b3ed5a04209bdd7d58b9a3c073f32))
+- Fixed qrCode loading (fix [#1422](https://github.com/wppconnect-team/wppconnect/issues/1422)) ([9b66878](https://github.com/wppconnect-team/wppconnect/commit/9b66878fe728e36ee70d1b2e4e425c7e0ee54814))
+- Removed unused modules ([#1422](https://github.com/wppconnect-team/wppconnect/issues/1422)) ([965be01](https://github.com/wppconnect-team/wppconnect/commit/965be0131645d3adbe5744a7a46428ddcda40c27))
 
-# 1.19.0 (2022-11-02)
+### Features
 
-## 1.18.1 (2022-10-20)
+- Added client.editBusinessProfile and client.getBusinessProfile ([bb7390e](https://github.com/wppconnect-team/wppconnect/commit/bb7390e8b1254fd230aa14caf018d0e961c71151))
+
+# [1.19.0](https://github.com/wppconnect-team/wppconnect/compare/v1.18.1...v1.19.0) (2022-11-02)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.13.4 ([e61ebb1](https://github.com/wppconnect-team/wppconnect/commit/e61ebb1a67865835facb29126e5776d110450336))
+- **deps:** update dependency @wppconnect/wa-js to ^2.14.1 ([#1398](https://github.com/wppconnect-team/wppconnect/issues/1398)) ([2860af3](https://github.com/wppconnect-team/wppconnect/commit/2860af32dcc4715c25f648d9350db13aeeec9542))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.176 ([#1377](https://github.com/wppconnect-team/wppconnect/issues/1377)) ([17e46a3](https://github.com/wppconnect-team/wppconnect/commit/17e46a3298fd217cac3ac751d202ae3ba7401c98))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.177 ([8dcc853](https://github.com/wppconnect-team/wppconnect/commit/8dcc85387d5346af0375f3645ea0a7e58edfaaa1))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.183 ([0b6179e](https://github.com/wppconnect-team/wppconnect/commit/0b6179ef1389ca46f37028294176ec651c343fdd))
+- Fix TS2416 error on dist build ([#1386](https://github.com/wppconnect-team/wppconnect/issues/1386)) ([b7ecdc1](https://github.com/wppconnect-team/wppconnect/commit/b7ecdc1176e22529f4204ad536ccbc956ca7eb69))
+- Fixed return for client.sendPollMessage ([0876eba](https://github.com/wppconnect-team/wppconnect/commit/0876eba4b9060ae593af917265fdf3a3e7946de7))
+- Fixed return on added to group ([e23b49b](https://github.com/wppconnect-team/wppconnect/commit/e23b49b6540164fc9e22cc9e9664cea1e7eebf49))
+
+### Features
+
+- Added client.sendPollMessage ([3acdfe3](https://github.com/wppconnect-team/wppconnect/commit/3acdfe3cfeacc610304242e134e5fdbb415b234e))
+
+## [1.18.1](https://github.com/wppconnect-team/wppconnect/compare/v1.18.0...v1.18.1) (2022-10-20)
 
 ### Bug Fixes
 
 - Fixed "Checking phone is connected" without autoClose ([ad63fb5](https://github.com/wppconnect-team/wppconnect/commit/ad63fb56a2255a67bcb16227fa6a61210f8633d1))
+- Fixed session re-initialization ([b523416](https://github.com/wppconnect-team/wppconnect/commit/b523416fe45cbe389ba6bffbc9aa715293fb3e73))
 
-# 1.18.0 (2022-10-18)
+### Features
+
+- Added more log for WhatsApp page loading ([62c9bf1](https://github.com/wppconnect-team/wppconnect/commit/62c9bf10c085edf0fb0c42222e0bd9a58030763c))
+
+# [1.18.0](https://github.com/wppconnect-team/wppconnect/compare/v1.17.1...v1.18.0) (2022-10-18)
+
+### Bug Fixes
+
+- Avoid localStorage override for multidevice ([7d10159](https://github.com/wppconnect-team/wppconnect/commit/7d10159f80485df81adf29627c5f0b34a90f4ea0))
+- **deps:** update dependency @wppconnect/wa-js to ^2.13.3 ([20328c7](https://github.com/wppconnect-team/wppconnect/commit/20328c79873babc7bdc6db11d9b09819990ac874))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.175 ([eb885c6](https://github.com/wppconnect-team/wppconnect/commit/eb885c6de2daa34dc3f9528d3aad8da2c4d10181))
+- Fixed paired session detection (fix [#1339](https://github.com/wppconnect-team/wppconnect/issues/1339)) ([bdfd9d9](https://github.com/wppconnect-team/wppconnect/commit/bdfd9d9a8b4f8202f5405d62ea34b2d78ccb164e))
+- Improved script inject to fix [#1366](https://github.com/wppconnect-team/wppconnect/issues/1366) ([4f7bd6e](https://github.com/wppconnect-team/wppconnect/commit/4f7bd6ebb322f18f0c8f5c245d6289f5871a6e99))
 
 ### Features
 
 - Improved QRCode re-scan (fix [#1189](https://github.com/wppconnect-team/wppconnect/issues/1189)) ([8ec5264](https://github.com/wppconnect-team/wppconnect/commit/8ec5264e55e01c15efd3e3c273c54e34cad166c9))
 
-## 1.17.1 (2022-10-10)
+## [1.17.1](https://github.com/wppconnect-team/wppconnect/compare/v1.17.0...v1.17.1) (2022-10-10)
 
 ### Bug Fixes
 
 - **deps:** update dependency @wppconnect/wa-js to ^2.13.1 ([#1364](https://github.com/wppconnect-team/wppconnect/issues/1364)) ([ff92035](https://github.com/wppconnect-team/wppconnect/commit/ff92035cb05abc21a8e241d8c7d3d5be4614edfb))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.163 ([1c0b055](https://github.com/wppconnect-team/wppconnect/commit/1c0b055723d86b07e0b6326245bd42435e3c0ed7))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.165 ([22a10f8](https://github.com/wppconnect-team/wppconnect/commit/22a10f87522dcbde4cf1b911f5156cc3643bf0c8))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.168 ([54b17c0](https://github.com/wppconnect-team/wppconnect/commit/54b17c03a8ae4789841390eaf690104cb43609b8))
+- page on load order ([1228a06](https://github.com/wppconnect-team/wppconnect/commit/1228a068e5ee22807d0259026d00ab3022203dcb))
 
-# 1.17.0 (2022-09-17)
+# [1.17.0](https://github.com/wppconnect-team/wppconnect/compare/v1.16.1...v1.17.0) (2022-09-17)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^2.11.0 ([43ae2c6](https://github.com/wppconnect-team/wppconnect/commit/43ae2c648232346aea6ebbcc9d2374482724c65b))
+- **deps:** update dependency @wppconnect/wa-js to ^2.11.1 ([8c5de17](https://github.com/wppconnect-team/wppconnect/commit/8c5de17deb1abdb7595a38dd9043bd2fc094d8d9))
+- **deps:** update dependency @wppconnect/wa-js to ^2.12.0 ([#1333](https://github.com/wppconnect-team/wppconnect/issues/1333)) (fix [#1330](https://github.com/wppconnect-team/wppconnect/issues/1330)) ([ecda056](https://github.com/wppconnect-team/wppconnect/commit/ecda056fab342ebe52b40dc8266fdb091fcf93e0))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.126 ([#1269](https://github.com/wppconnect-team/wppconnect/issues/1269)) ([fa954fc](https://github.com/wppconnect-team/wppconnect/commit/fa954fcb872945ea671b7616100c04b7b8ce9846))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.128 ([c853397](https://github.com/wppconnect-team/wppconnect/commit/c853397280cd790c4ba77236b4653840e46d180f))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.131 ([f3588f7](https://github.com/wppconnect-team/wppconnect/commit/f3588f7a562237ba55b0e64670835cc3f4e1f826))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.133 ([0a04393](https://github.com/wppconnect-team/wppconnect/commit/0a0439393b970f5e1558c35fc7343027c9f9d8ca))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.135 ([a9376cc](https://github.com/wppconnect-team/wppconnect/commit/a9376cc0e3c09541b7ae4720d3acda076b08b482))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.143 ([3138b36](https://github.com/wppconnect-team/wppconnect/commit/3138b36efc965d8628fe4fe942cce7543daa17ec))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.145 ([1426644](https://github.com/wppconnect-team/wppconnect/commit/14266448f20790a5c7ee7f146656dd1ef7bd0455))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.150 ([7c4ff9e](https://github.com/wppconnect-team/wppconnect/commit/7c4ff9e50e216d12f3f2cc5e96bd9c10a5b3894a))
 - **deps:** update dependency @wppconnect/wa-version to ^1.1.154 ([#1334](https://github.com/wppconnect-team/wppconnect/issues/1334)) ([daa94ef](https://github.com/wppconnect-team/wppconnect/commit/daa94ef808660bd5acb143ceb8c9bff9a3a25a18))
+- Fixed setOnlinePresence method ([1ae2658](https://github.com/wppconnect-team/wppconnect/commit/1ae265808b2d167a51f09bc86334640d5e818ea0))
+- Updated WhatsApp WEB version to 2.2234.x ([3edc013](https://github.com/wppconnect-team/wppconnect/commit/3edc013a9d0e19d608fee77d4b9fccbccb0d1bd8))
 
-## 1.16.1 (2022-08-09)
+### Features
 
-# 1.16.0 (2022-08-05)
+- Added client.getLabelById function (fix [#278](https://github.com/wppconnect-team/wppconnect/issues/278)) ([5ecfcb6](https://github.com/wppconnect-team/wppconnect/commit/5ecfcb6d042f1077f1f1678321ce674f45d626af))
+- Added client.getPlatformFromMessage function ([756775e](https://github.com/wppconnect-team/wppconnect/commit/756775e837ef39028682014afc091e0d5106ae7a))
+- Added client.markPlayed function (fix [#706](https://github.com/wppconnect-team/wppconnect/issues/706)) ([72a70f3](https://github.com/wppconnect-team/wppconnect/commit/72a70f3c313c3772d18b436d88d1b988aa84f594))
+- Added client.sendReadStatus function ([#673](https://github.com/wppconnect-team/wppconnect/issues/673)) ([f0361b9](https://github.com/wppconnect-team/wppconnect/commit/f0361b9c2a7b582c4d652bdc4d589d6464411330))
+- Added functions to get, edit, delete products and collections of catalog (fix [#363](https://github.com/wppconnect-team/wppconnect/issues/363), fix [#905](https://github.com/wppconnect-team/wppconnect/issues/905)) ([bbcdfa9](https://github.com/wppconnect-team/wppconnect/commit/bbcdfa947c44cc77056077b8a2b80ea237f584c6))
+
+## [1.16.1](https://github.com/wppconnect-team/wppconnect/compare/v1.16.0...v1.16.1) (2022-08-09)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.10.1 ([5928fd5](https://github.com/wppconnect-team/wppconnect/commit/5928fd5a7f61ecfe863d28b14c023d67f39ed6e4))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.123 ([3b0ba0e](https://github.com/wppconnect-team/wppconnect/commit/3b0ba0eba13d9b051d7b157b659fe17e262e546e))
+- Fixed WAPI is not defined (fix wppconnect-team/wppconnect-server[#864](https://github.com/wppconnect-team/wppconnect/issues/864)) ([1e9b246](https://github.com/wppconnect-team/wppconnect/commit/1e9b24640904661fa1534d6834a9bb0ec2940881))
+
+# [1.16.0](https://github.com/wppconnect-team/wppconnect/compare/v1.15.0...v1.16.0) (2022-08-05)
 
 ### Bug Fixes
 
 - **deps:** update dependency @wppconnect/wa-js to ^2.10.0 ([dc8133a](https://github.com/wppconnect-team/wppconnect/commit/dc8133a2896c011830c874c94c780acd9368a25a))
+- **deps:** update dependency @wppconnect/wa-js to ^2.8.2 ([28d4524](https://github.com/wppconnect-team/wppconnect/commit/28d4524807faab0dd4a0b7f93f1557db1dcc9f98))
+- **deps:** update dependency @wppconnect/wa-js to ^2.9.0 ([#1252](https://github.com/wppconnect-team/wppconnect/issues/1252)) ([34b7ba9](https://github.com/wppconnect-team/wppconnect/commit/34b7ba979f1f4c6aaae66cb08c165c0b835b40f1))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.116 ([74a36ba](https://github.com/wppconnect-team/wppconnect/commit/74a36ba000dd279cda598e37789e3045eee63610))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.121 ([6cf8ee3](https://github.com/wppconnect-team/wppconnect/commit/6cf8ee3d10dbd7f7466cc03483b34a4fd7341c66))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.122 ([5427ed7](https://github.com/wppconnect-team/wppconnect/commit/5427ed77ee18c25da4da64acd735326b34ef080c))
+- getAllLabels return null ([#1235](https://github.com/wppconnect-team/wppconnect/issues/1235)) ([515d842](https://github.com/wppconnect-team/wppconnect/commit/515d8429bb1189ca352542d28d088774fe1c24fb))
+- OnParticipantsChanged ([#1250](https://github.com/wppconnect-team/wppconnect/issues/1250)) ([76b179a](https://github.com/wppconnect-team/wppconnect/commit/76b179a817433e3bc77f5e2dd92ecb337278d397))
 
-# 1.15.0 (2022-07-20)
+### Features
 
-## 1.14.5 (2022-07-11)
+- Loading Screen callback function with percent and message ([#1218](https://github.com/wppconnect-team/wppconnect/issues/1218)) ([1a11117](https://github.com/wppconnect-team/wppconnect/commit/1a111172794ace9bfbfe7c371bd537a86707118a))
 
-## 1.14.4 (2022-06-20)
+# [1.15.0](https://github.com/wppconnect-team/wppconnect/compare/v1.14.5...v1.15.0) (2022-07-20)
 
-## 1.14.3 (2022-06-17)
+### Bug Fixes
+
+- remove unnecessary get ([9043649](https://github.com/wppconnect-team/wppconnect/commit/904364971932be7cbdc96428a6e996d195c72ec4))
+- Set Profile Icon for receive urls ([c444938](https://github.com/wppconnect-team/wppconnect/commit/c444938da9fcbe13ee584fc064b5f1fdb76439de))
+
+### Features
+
+- Added Labels functions ([7d19a0d](https://github.com/wppconnect-team/wppconnect/commit/7d19a0d1938e2b1d2d8677845e47229812049b2a))
+- Added onReactionMessage event ([2c25b01](https://github.com/wppconnect-team/wppconnect/commit/2c25b017a49cf0066bb499fd5b167aa314d80a0d))
+- Added SendImageStorie and sendTextStorie ([bd17cfd](https://github.com/wppconnect-team/wppconnect/commit/bd17cfd3a93dbbb6aba95ed21a541998f6969772))
+- Added sendReactionToMessage function ([edbec84](https://github.com/wppconnect-team/wppconnect/commit/edbec8463552bafea6160ccf75a225fb49904a76))
+- Added sendVideoStatus ([3984ca0](https://github.com/wppconnect-team/wppconnect/commit/3984ca07bcfce55f434c5a19e92d3778521862d3))
+- Added setGroupIco function ([08b06f4](https://github.com/wppconnect-team/wppconnect/commit/08b06f4eba95611aaa5d46d202dcb954f5164e05))
+
+## [1.14.5](https://github.com/wppconnect-team/wppconnect/compare/v1.14.4...v1.14.5) (2022-07-11)
+
+### Bug Fixes
+
+- Adding Missing Typing in GroupMetadata ([30f1caa](https://github.com/wppconnect-team/wppconnect/commit/30f1caa70166f56cef1b05a60deb9ac01ab16528))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.104 ([3e0a33d](https://github.com/wppconnect-team/wppconnect/commit/3e0a33d1f395fd66cc4ced8ed92a32fb5ad1fec9))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.98 ([e342c41](https://github.com/wppconnect-team/wppconnect/commit/e342c41e5edcc321f08ca944ea4190401e8fc723))
+- Fixed getAllGroups method (fix [#1089](https://github.com/wppconnect-team/wppconnect/issues/1089), fix [#1188](https://github.com/wppconnect-team/wppconnect/issues/1188)) ([4efb0cf](https://github.com/wppconnect-team/wppconnect/commit/4efb0cf07f5d0e4dbce60e7ff2b18df38a14e77d))
+- Improved onAnyMessage for ciphertext messages ([7eb9e59](https://github.com/wppconnect-team/wppconnect/commit/7eb9e5931e1300f1f9550a6e9e906efcc1d5a8c2))
+- Improved onMessage event to re-trigger message after ciphertext (fix [#1065](https://github.com/wppconnect-team/wppconnect/issues/1065)) ([b9ff808](https://github.com/wppconnect-team/wppconnect/commit/b9ff8082dd9c3f1a781784396e83d7b309465490))
+- Improved onPresenceChanged event ([d71835f](https://github.com/wppconnect-team/wppconnect/commit/d71835fbea80e72308d82913744882659e8f23b9))
+- **typings:** Adding Missing Typing in Chat ([a6afdd1](https://github.com/wppconnect-team/wppconnect/commit/a6afdd188770ca31453864703a3e8ccd0cd233d6))
+- Updated @wppconnect/wa-js to v2.8.1 (fix [#1196](https://github.com/wppconnect-team/wppconnect/issues/1196)) ([8ecaa6b](https://github.com/wppconnect-team/wppconnect/commit/8ecaa6b3018b808ac6237e7ad09641e81637fd52))
+
+### Features
+
+- Added poweredBy config for Google Analytics ([b0883f3](https://github.com/wppconnect-team/wppconnect/commit/b0883f34450e4204b330b4d053b06d7750852db7))
+- options for GA and linkPreviewApiServers ([#1186](https://github.com/wppconnect-team/wppconnect/issues/1186)) ([4479f9b](https://github.com/wppconnect-team/wppconnect/commit/4479f9baf56c2a924de8b20515c4215039603753))
+
+## [1.14.4](https://github.com/wppconnect-team/wppconnect/compare/v1.14.3...v1.14.4) (2022-06-20)
+
+### Bug Fixes
+
+- **deps:** update dependency @wppconnect/wa-js to ^2.7.3 ([ef777ee](https://github.com/wppconnect-team/wppconnect/commit/ef777ee15cd084da122ef39087960202ff9be4f7))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.97 ([e3fd5df](https://github.com/wppconnect-team/wppconnect/commit/e3fd5dfa59ed192b97f56bd44930e258f34f6170))
+
+## [1.14.3](https://github.com/wppconnect-team/wppconnect/compare/v1.14.2...v1.14.3) (2022-06-17)
 
 ### Bug Fixes
 
 - **deps:** update dependency @wppconnect/wa-js to ^2.7.2 ([#1181](https://github.com/wppconnect-team/wppconnect/issues/1181)) ([5208e62](https://github.com/wppconnect-team/wppconnect/commit/5208e621cf79ca5d80cca5ecf3c7b9068ca44e91))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.93 ([5293613](https://github.com/wppconnect-team/wppconnect/commit/5293613254e3a04388a9a8b916dd13489f2cae05))
 
-## 1.14.2 (2022-06-11)
+## [1.14.2](https://github.com/wppconnect-team/wppconnect/compare/v1.14.1...v1.14.2) (2022-06-11)
 
 ### Bug Fixes
 
 - Added filename for sendFile when is using path or URL (fix [#1168](https://github.com/wppconnect-team/wppconnect/issues/1168)) ([5534fad](https://github.com/wppconnect-team/wppconnect/commit/5534fad0e056563cc3ce6b7699ea06f5eaff6da8))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.92 ([62e05c9](https://github.com/wppconnect-team/wppconnect/commit/62e05c944dea5b12066c4d64b9697884ce55b64d))
 
-## 1.14.1 (2022-06-08)
+## [1.14.1](https://github.com/wppconnect-team/wppconnect/compare/v1.14.0...v1.14.1) (2022-06-08)
 
-# 1.14.0 (2022-06-08)
+### Bug Fixes
+
+- Fixed log level for 'Using browser folder' ([10c42f3](https://github.com/wppconnect-team/wppconnect/commit/10c42f36589b00d5d1a87d3bb6c345eb1d018413))
+
+# [1.14.0](https://github.com/wppconnect-team/wppconnect/compare/v1.13.3...v1.14.0) (2022-06-08)
 
 ### Bug Fixes
 
 - **deps:** update dependency @wppconnect/wa-js to ^2.6.0 ([27d5a52](https://github.com/wppconnect-team/wppconnect/commit/27d5a523c1dfa1a22c8be08cd7ff6d03af1fc0b1))
+- **deps:** update dependency @wppconnect/wa-version to ^1.1.89 ([d65437d](https://github.com/wppconnect-team/wppconnect/commit/d65437debeb6656ec5dcc50e7ff7d04f82f075cf))
+- Fixed compatibility with WhatsApp WEB >= 2.2220.8 ([1a96ab1](https://github.com/wppconnect-team/wppconnect/commit/1a96ab1152e01921025232228f254f3deaf2a8ff))
+- Updated the WhatsApp version to 2.2220.X ([8ad94be](https://github.com/wppconnect-team/wppconnect/commit/8ad94be57828442358738ac49a4d45ea8867ff6c))
+- Updated User-Agend ([2353013](https://github.com/wppconnect-team/wppconnect/commit/23530132b75912d9f018f47b80280fdb77d03fb8))
 
-## 1.13.3 (2022-06-01)
+### Features
+
+- Automatic use tokens folder for browser session ([f082612](https://github.com/wppconnect-team/wppconnect/commit/f082612f2a9e887c03ffa28fb10c5db8ea485972))
+- Full rework of sendFile to allow options ([b1b712e](https://github.com/wppconnect-team/wppconnect/commit/b1b712ebedfaa772182631bfc7a79d512bcfad6a))
+- Full rework of sendLocation to allow options ([d9fb419](https://github.com/wppconnect-team/wppconnect/commit/d9fb419f92709eeceecf55d8c0405cbe941e563d))
+
+### BREAKING CHANGES
+
+- Changed the sendLocation result
+- Changed the function result
+
+## [1.13.3](https://github.com/wppconnect-team/wppconnect/compare/v1.13.2...v1.13.3) (2022-06-01)
 
 ### Bug Fixes
 
 - Clear all token data when disconnected (fix [#1147](https://github.com/wppconnect-team/wppconnect/issues/1147)) ([4abcfed](https://github.com/wppconnect-team/wppconnect/commit/4abcfed97778ddb619df65fec0b1c3d0dc4debac))
+- **deps:** update dependency @wppconnect/wa-js to ^2.4.1 ([#1139](https://github.com/wppconnect-team/wppconnect/issues/1139)) ([3407555](https://github.com/wppconnect-team/wppconnect/commit/3407555a4762e25afba1ddf71202265aab9284bc))
+- Fixed and deprecated method sendLinkPreview (fix: [#1146](https://github.com/wppconnect-team/wppconnect/issues/1146)) ([d2bd6aa](https://github.com/wppconnect-team/wppconnect/commit/d2bd6aaeda02f8c607b5d3fa3a79faa2432d8fec))
+- Fixed and deprecated sendMessageWithThumb method (fix [#1067](https://github.com/wppconnect-team/wppconnect/issues/1067)) ([d0c0ad0](https://github.com/wppconnect-team/wppconnect/commit/d0c0ad019a5d56aacd226144ac6633632b8c53c9))
+- Fixed sendImageAsStickerGif and sendImageAsSticker methods (fix [#1138](https://github.com/wppconnect-team/wppconnect/issues/1138)) ([8fcd94a](https://github.com/wppconnect-team/wppconnect/commit/8fcd94addfbb7b698abc64da6f386d1acb19f826))
 
-## 1.13.2 (2022-05-28)
+## [1.13.2](https://github.com/wppconnect-team/wppconnect/compare/v1.13.1...v1.13.2) (2022-05-28)
 
 ### Bug Fixes
 
+- **deps:** update dependency @wppconnect/wa-js to ^2.3.0 ([f1675f3](https://github.com/wppconnect-team/wppconnect/commit/f1675f3b93652ed3fbc692a2d2f8cd4de4a1f8ef))
+- **deps:** update dependency @wppconnect/wa-js to ^2.4.0 (fix [#1117](https://github.com/wppconnect-team/wppconnect/issues/1117)) ([b7b8372](https://github.com/wppconnect-team/wppconnect/commit/b7b83726d383606da31c0a97be54434d35096540))
 - Migrate archiveChat and pinChat methods to WA-JS ([cee7e1c](https://github.com/wppconnect-team/wppconnect/commit/cee7e1ced23409d66365e42a35602265e0c09536))
+- Updated browser user-agent ([cb8584a](https://github.com/wppconnect-team/wppconnect/commit/cb8584aa2d9786f582ab9cd4edb848e2f7e3e2a6))
 
-## 1.13.1 (2022-05-10)
+## [1.13.1](https://github.com/wppconnect-team/wppconnect/compare/v1.13.0...v1.13.1) (2022-05-10)
 
-# 1.13.0 (2022-04-25)
+# [1.13.0](https://github.com/wppconnect-team/wppconnect/compare/v1.12.8...v1.13.0) (2022-04-25)
 
 ### Features
 
 - Improved chat state to keep alive and online ([ba82005](https://github.com/wppconnect-team/wppconnect/commit/ba82005f11b8ecc8dacee08304b7d3a66bbea6b0))
+- Updated the WA-JS ([441850b](https://github.com/wppconnect-team/wppconnect/commit/441850bd52afba069ae788eb5c5eb1bc82139823))
+- Updated WhatsApp WEB to 2.2214.9 ([5ad6045](https://github.com/wppconnect-team/wppconnect/commit/5ad6045a3bac56ba53b636f6f05cc9eedc2b3289))
 
-## 1.12.8 (2022-03-13)
+## [1.12.8](https://github.com/wppconnect-team/wppconnect/compare/v1.12.7...v1.12.8) (2022-03-13)
 
 ### Bug Fixes
 
+- Fixed 'Unhandled Rejection' that was killing the application ([f865d48](https://github.com/wppconnect-team/wppconnect/commit/f865d48791f11c2d27f41ccda8a8a1493e90be19))
+- Fixed deleteMessage ([#937](https://github.com/wppconnect-team/wppconnect/issues/937)) and onRevokedMessage ([#932](https://github.com/wppconnect-team/wppconnect/issues/932)) ([880489e](https://github.com/wppconnect-team/wppconnect/commit/880489e03eb826e97c428e1169f745aa0b004331))
 - Fixed stuck state after logout ([bb9695a](https://github.com/wppconnect-team/wppconnect/commit/bb9695a61404a062daf1d0995ad2bb10af7c5006))
+- Stop firing new message for status@broadcast (fix [#942](https://github.com/wppconnect-team/wppconnect/issues/942)) ([4b2c68b](https://github.com/wppconnect-team/wppconnect/commit/4b2c68be1a91973b0b748dc6a25bb35d70cc7225))
 
-## 1.12.7 (2022-03-03)
+## [1.12.7](https://github.com/wppconnect-team/wppconnect/compare/v1.12.6...v1.12.7) (2022-03-03)
 
 ### Bug Fixes
 
 - Fixed onParticipantsChanged and onPresenceChanged function (fix [#864](https://github.com/wppconnect-team/wppconnect/issues/864), fix [#911](https://github.com/wppconnect-team/wppconnect/issues/911)) ([aff7f6c](https://github.com/wppconnect-team/wppconnect/commit/aff7f6cd34c22c086789ca4871c3113d8d8b2bb8))
 
-## 1.12.6 (2022-02-22)
+## [1.12.6](https://github.com/wppconnect-team/wppconnect/compare/v1.12.5...v1.12.6) (2022-02-22)
 
 ### Bug Fixes
 
+- ajuste versao default para 2.2204 ([#893](https://github.com/wppconnect-team/wppconnect/issues/893)) ([c910958](https://github.com/wppconnect-team/wppconnect/commit/c910958df2b69f42185e673b1888e418100d35bf))
+- Fixed code for getGroupAdmins (fix [#899](https://github.com/wppconnect-team/wppconnect/issues/899)) ([a50809e](https://github.com/wppconnect-team/wppconnect/commit/a50809e80e791f8a42da58c78f2d7f2bacfb41c3))
 - Fixed getGroupMembersIds and getGroupMembers for large chats (fix [#892](https://github.com/wppconnect-team/wppconnect/issues/892)) ([9cc34a5](https://github.com/wppconnect-team/wppconnect/commit/9cc34a5fddef52b01feba6194fff31aa19b388f0))
+- Fixed multidevice don't keep auth (fix [#866](https://github.com/wppconnect-team/wppconnect/issues/866), fix [#784](https://github.com/wppconnect-team/wppconnect/issues/784)) ([06cbd88](https://github.com/wppconnect-team/wppconnect/commit/06cbd885299087d5007381235174a90b16db2262))
+- Removed unused functions (fix [#862](https://github.com/wppconnect-team/wppconnect/issues/862)) ([34773b7](https://github.com/wppconnect-team/wppconnect/commit/34773b740c2f65d9ddbabfa2aaf2eb42eb090276))
 
-## 1.12.5 (2022-02-06)
+## [1.12.5](https://github.com/wppconnect-team/wppconnect/compare/v1.12.4...v1.12.5) (2022-02-06)
 
-## 1.12.4 (2022-01-22)
+### Bug Fixes
+
+- Updated functions to use WA-JS 1.1.16 ([f218c3b](https://github.com/wppconnect-team/wppconnect/commit/f218c3bf198e0886423cb0de984e10eee193d29e))
+
+## [1.12.4](https://github.com/wppconnect-team/wppconnect/compare/v1.12.3...v1.12.4) (2022-01-22)
 
 ### Bug Fixes
 
 - Fixed getMessageById where the message is from status (fix [#823](https://github.com/wppconnect-team/wppconnect/issues/823)) ([ed57b97](https://github.com/wppconnect-team/wppconnect/commit/ed57b9700efd72f3de7c0c8d658d24b41f4da5d9))
+- Fixed return of getStatus (fix [#822](https://github.com/wppconnect-team/wppconnect/issues/822)) ([c0fc6d6](https://github.com/wppconnect-team/wppconnect/commit/c0fc6d6356abf042b1ebecd503bfc93b16776da8))
+- Fixed setProfilePic function (fix [#824](https://github.com/wppconnect-team/wppconnect/issues/824)) ([a8bd58b](https://github.com/wppconnect-team/wppconnect/commit/a8bd58bf7f70745a08849e962a51a5489cef5e9f))
 
-## 1.12.3 (2022-01-21)
+## [1.12.3](https://github.com/wppconnect-team/wppconnect/compare/v1.12.2...v1.12.3) (2022-01-21)
 
 ### Bug Fixes
 
+- Fixed getStatus function (fix [#804](https://github.com/wppconnect-team/wppconnect/issues/804)) ([f02988c](https://github.com/wppconnect-team/wppconnect/commit/f02988cfb93ab833269f3cc1e1104f3f708cfcd6))
+- Fixed markIsRead call (fix [#776](https://github.com/wppconnect-team/wppconnect/issues/776)) ([037000d](https://github.com/wppconnect-team/wppconnect/commit/037000dd7676118214e8127b2d9287819cdadd0b))
+- Updated @wppconnect/wa-js to v1.1.6 ([b8546d5](https://github.com/wppconnect-team/wppconnect/commit/b8546d51ecf988e661da7361a1fee7e2fc91225b))
 - Updated @wppconnect/wa-js to v1.1.9 ([5074de1](https://github.com/wppconnect-team/wppconnect/commit/5074de182f401b8f8e6b382aa513ca2cc65ef488))
 
-## 1.12.2 (2022-01-15)
+### Features
 
-## 1.12.1 (2022-01-14)
+- Added WA-JS version info ([df36ff6](https://github.com/wppconnect-team/wppconnect/commit/df36ff63714def01c11604626f57f3f2b73de677))
 
-# 1.12.0 (2022-01-08)
+## [1.12.2](https://github.com/wppconnect-team/wppconnect/compare/v1.12.1...v1.12.2) (2022-01-15)
+
+### Bug Fixes
+
+- Fixed evaluate function when the return is null (fix [#791](https://github.com/wppconnect-team/wppconnect/issues/791)) ([7c33419](https://github.com/wppconnect-team/wppconnect/commit/7c3341945e0d55a525e25f807748781332995508))
+- Fixed getNumberProfile function (fix [#793](https://github.com/wppconnect-team/wppconnect/issues/793)) ([1bda9a6](https://github.com/wppconnect-team/wppconnect/commit/1bda9a6884385413ad8a1ee9caef1382fcb321f0))
+- Migrated livelocation to WA-JS ([5a31d4c](https://github.com/wppconnect-team/wppconnect/commit/5a31d4c18ceeb8e9bb225fbe123fcc3710fe598c))
+- Updated @wppconnect/wa-js (fix: [#792](https://github.com/wppconnect-team/wppconnect/issues/792)) ([236a15a](https://github.com/wppconnect-team/wppconnect/commit/236a15a2e266d2ba292d2cc316d072b5623964a9))
+
+## [1.12.1](https://github.com/wppconnect-team/wppconnect/compare/v1.12.0...v1.12.1) (2022-01-14)
+
+### Bug Fixes
+
+- Added WABrowserId to token file for MD ([#784](https://github.com/wppconnect-team/wppconnect/issues/784)) ([295538f](https://github.com/wppconnect-team/wppconnect/commit/295538f9986d044db2b4e8b41d4a89752c297e2b))
+- Fixed send error for new WhatsApp version (fix [#788](https://github.com/wppconnect-team/wppconnect/issues/788)) ([20acdf6](https://github.com/wppconnect-team/wppconnect/commit/20acdf64f0c9a8c71fa40429788ad26c420207fc))
+
+# [1.12.0](https://github.com/wppconnect-team/wppconnect/compare/v1.11.1...v1.12.0) (2022-01-08)
 
 ### Bug Fixes
 
 - Fixed downloadMedia (fix [#463](https://github.com/wppconnect-team/wppconnect/issues/463)) ([ea9ba75](https://github.com/wppconnect-team/wppconnect/commit/ea9ba75ec3e24103a7ccf55b0df43ffc8d46271b))
+- Fixed return of sendContactVcard (fix [#739](https://github.com/wppconnect-team/wppconnect/issues/739)) ([ddcdb1f](https://github.com/wppconnect-team/wppconnect/commit/ddcdb1fd24e88c9cb03587a396f0ab5d5ad99f36))
+- Updated @wppconnect/wa-js to (1.1.2) ([3f68c6d](https://github.com/wppconnect-team/wppconnect/commit/3f68c6ddb2bb47ddee15e44af6b3e006ec7cd57a))
 
-## 1.11.1 (2021-12-09)
+## [1.11.1](https://github.com/wppconnect-team/wppconnect/compare/v1.11.0...v1.11.1) (2021-12-09)
 
 ### Bug Fixes
 
+- Disabled link preview for beta/multidevice (fix [#707](https://github.com/wppconnect-team/wppconnect/issues/707)) ([0d9e2ee](https://github.com/wppconnect-team/wppconnect/commit/0d9e2ee97cd904ef05f0cb3d18cc8e779de14a40))
 - Fixed getNumberProfile function (fix [#717](https://github.com/wppconnect-team/wppconnect/issues/717)) ([89a0720](https://github.com/wppconnect-team/wppconnect/commit/89a072066991213d301739b0788d19f05a9b0912))
+- Fixed sendMessageWithThumb function with URL (fix [#703](https://github.com/wppconnect-team/wppconnect/issues/703)) ([8f38ee8](https://github.com/wppconnect-team/wppconnect/commit/8f38ee820939491cb905f38f50e7850932e2647b))
+- sendMentioned function to WA-JS (close [#702](https://github.com/wppconnect-team/wppconnect/issues/702)) ([4f4a46e](https://github.com/wppconnect-team/wppconnect/commit/4f4a46edb6f5db5cfbd71cd7816cf693f400c989))
 
-# 1.11.0 (2021-12-09)
+# [1.11.0](https://github.com/wppconnect-team/wppconnect/compare/v1.10.3...v1.11.0) (2021-12-09)
 
 ### Bug Fixes
 
+- Fixed getGroupInfoFromInviteLink function (fix [#677](https://github.com/wppconnect-team/wppconnect/issues/677)) ([bd1c7da](https://github.com/wppconnect-team/wppconnect/commit/bd1c7daa023772e13a28448493cbd8d66306561a))
 - Fixed initialization of onPresenceChanged (fix [#704](https://github.com/wppconnect-team/wppconnect/issues/704)) ([0470ea8](https://github.com/wppconnect-team/wppconnect/commit/0470ea8a0fd15727f91e18c913b96f3c1e1f79a9))
+- Fixed setGroupProperty for Beta MultiDevice (fix [#670](https://github.com/wppconnect-team/wppconnect/issues/670)) ([baed510](https://github.com/wppconnect-team/wppconnect/commit/baed510b63a48c827a543266ab0dd2932521e465))
+- Migrated addAndSendMsgToChat and sendTextMsgToChat functions to WA-JS ([eb9677c](https://github.com/wppconnect-team/wppconnect/commit/eb9677cede28c16624b2e503916200d1f55a305b))
+- Migrated blocklist functions to WA-JS ([a0e0f5b](https://github.com/wppconnect-team/wppconnect/commit/a0e0f5beb9b34e64508f92da5fe86c93c0dab3fb))
+- Migrated Chat and Msg stores to WA-JS ([68e7a54](https://github.com/wppconnect-team/wppconnect/commit/68e7a547a60577a93ec78aad6ea19a33a2a6eba6))
+- Migrated many stores to WA-JS ([b55dab3](https://github.com/wppconnect-team/wppconnect/commit/b55dab394bce81da6e53abcecfa42c79e3a24daf))
+- Migrated ProfilePicThumb functions to WA-JS ([5cd98d0](https://github.com/wppconnect-team/wppconnect/commit/5cd98d001c11eeff3a83d6f616bc0a2a8ad03bf6))
+- Migrated sendSeen and markUnseenMessage to WA-JS ([f5ebd13](https://github.com/wppconnect-team/wppconnect/commit/f5ebd13df5a3f016521e765a721f2109c7b345f9))
+- Migrated startTyping and stopTyping function to WA-JS ([13d12f6](https://github.com/wppconnect-team/wppconnect/commit/13d12f63333a18176febacf9b5bdbb3a4d40439f))
+- Migrated State store to WA-JS ([e040978](https://github.com/wppconnect-team/wppconnect/commit/e0409780832945b502539b49c52d16e56d0aebfb))
+- Migrated to WA-JS loader and increase timeout (fix [#684](https://github.com/wppconnect-team/wppconnect/issues/684)) ([92301da](https://github.com/wppconnect-team/wppconnect/commit/92301da4b44910e5e1bfa574c992e04af1a4a78b))
 
-## 1.10.3 (2021-11-18)
+### Features
 
-## 1.10.2 (2021-11-15)
+- Added options and buttons for sendText function (close [#689](https://github.com/wppconnect-team/wppconnect/issues/689)) ([608afd8](https://github.com/wppconnect-team/wppconnect/commit/608afd82a0481d043b848e77879fa1259f2901db))
+- Added startRecording function and deprecated setChatState ([8e8d8d5](https://github.com/wppconnect-team/wppconnect/commit/8e8d8d57f0c40b4d5f5ed129b1317ff6cc4bbeb1))
+
+## [1.10.3](https://github.com/wppconnect-team/wppconnect/compare/v1.10.2...v1.10.3) (2021-11-18)
+
+### Bug Fixes
+
+- Disabled deviceName by default ([6cd1998](https://github.com/wppconnect-team/wppconnect/commit/6cd199864c5136f92d94b22cc07b703efcbf6669))
+- Fixed onAnyMessage event without msg body ([f34cd9b](https://github.com/wppconnect-team/wppconnect/commit/f34cd9bce42709e9efe58a3a4166879a4f595ccd))
+- Fixed sendMessageOptions to non contact (fix [#633](https://github.com/wppconnect-team/wppconnect/issues/633)) ([7921211](https://github.com/wppconnect-team/wppconnect/commit/7921211be20d8f70007acb7ca38238734efc5cfb))
+- Migrated MsgKey to WA-JS (fix [#658](https://github.com/wppconnect-team/wppconnect/issues/658)) ([2cf3e37](https://github.com/wppconnect-team/wppconnect/commit/2cf3e371b81b9fc8cbea51bb195d09e3834a89eb))
+- Migrated sendContactVcard and sendContactVcardList to WA-JS ([7e853cd](https://github.com/wppconnect-team/wppconnect/commit/7e853cdd71ac0724d21a7c006ec97b6aab2bcd9a))
+- Migrated UserPrefs to WA-JS ([363bb98](https://github.com/wppconnect-team/wppconnect/commit/363bb984d6c787ef73d4006f18f88b22b754f588))
+
+## [1.10.2](https://github.com/wppconnect-team/wppconnect/compare/v1.10.1...v1.10.2) (2021-11-15)
 
 ### Bug Fixes
 
 - Fixed call of createWid function (fix [#647](https://github.com/wppconnect-team/wppconnect/issues/647)) ([c381000](https://github.com/wppconnect-team/wppconnect/commit/c3810003a4f145f9c3ec54f49cde97ddbe01a164))
 
-## 1.10.1 (2021-11-11)
+## [1.10.1](https://github.com/wppconnect-team/wppconnect/compare/v1.10.0...v1.10.1) (2021-11-11)
+
+### Bug Fixes
+
+- Allowed to send media to non contact ([643f9b9](https://github.com/wppconnect-team/wppconnect/commit/643f9b9ee157bd1d20bd784c569ee6ebc8c453d2))
+- Fixed getAllUnreadMessages with beta MD (fix [#643](https://github.com/wppconnect-team/wppconnect/issues/643)) ([c70f44d](https://github.com/wppconnect-team/wppconnect/commit/c70f44d7927cfda8fbd47adebe74accfbbbf5b77))
+- Fixed group command after group creation (fix [#632](https://github.com/wppconnect-team/wppconnect/issues/632)) ([5f8ac35](https://github.com/wppconnect-team/wppconnect/commit/5f8ac35b8ba44d99adcfcfef4333504c22bbe3b7))
+- The first contact number cannot receive the first message ([#637](https://github.com/wppconnect-team/wppconnect/issues/637)) ([f39f1b7](https://github.com/wppconnect-team/wppconnect/commit/f39f1b70ef677b840acbb858f5880f73f149344a)), closes [#422](https://github.com/wppconnect-team/wppconnect/issues/422)
 
 ### Features
 
 - Updated to latest version of WhatsApp ([f6d01a3](https://github.com/wppconnect-team/wppconnect/commit/f6d01a390db9577f46fee0072637ece981e54780))
 
-# 1.10.0 (2021-11-06)
-
-## 1.9.4 (2021-10-21)
-
-## 1.9.3 (2021-10-21)
+# [1.10.0](https://github.com/wppconnect-team/wppconnect/compare/v1.9.4...v1.10.0) (2021-11-06)
 
 ### Bug Fixes
 
-- Fixed close method ([#579](https://github.com/wppconnect-team/wppconnect/issues/579)) ([ef42485](https://github.com/wppconnect-team/wppconnect/commit/ef42485505e9920b5b7826674949ed9d5e36d4e1))
+- token not saving in multi device ([#516](https://github.com/wppconnect-team/wppconnect/issues/516), [#585](https://github.com/wppconnect-team/wppconnect/issues/585)) ([520fd06](https://github.com/wppconnect-team/wppconnect/commit/520fd0693b51fcd8bed9af306536ca64612e490b))
+- Update sendPtt and sendPttFromBase64 to use WA-JS ([571a95d](https://github.com/wppconnect-team/wppconnect/commit/571a95dc0bd8dac1850ccb04e85b30add276f074))
+- Updated reply method to use WA-JS (fix [#627](https://github.com/wppconnect-team/wppconnect/issues/627)) ([fbb30dd](https://github.com/wppconnect-team/wppconnect/commit/fbb30dd74d281f3d25745910ce819a044103e761))
+- Updated sendGif, sendGifFromBase64 and sendVideoAsGifFromBase64 to use WA-JS ([44b4e95](https://github.com/wppconnect-team/wppconnect/commit/44b4e9510b99dfe7b926af4647ae1d47ad7ea291))
+- Updated sendImage and sendImageFromBase64 to use WA-JS ([fe4a019](https://github.com/wppconnect-team/wppconnect/commit/fe4a019d4c9ffdd5617e1393aba3f902a73a55ed))
 
-## 1.9.2 (2021-10-12)
+## [1.9.4](https://github.com/wppconnect-team/wppconnect/compare/v1.9.3...v1.9.4) (2021-10-21)
 
 ### Features
 
+- Added sendListMessage method ([4a64d77](https://github.com/wppconnect-team/wppconnect/commit/4a64d77ea2fbab8517e841b33117344711bdf9b2))
+
+## [1.9.3](https://github.com/wppconnect-team/wppconnect/compare/v1.9.2...v1.9.3) (2021-10-21)
+
+### Bug Fixes
+
+- Fixed clearChat method ([8ed1d86](https://github.com/wppconnect-team/wppconnect/commit/8ed1d86b7be33cae581bcd8a13ec5326e1beed87))
+- Fixed close method ([#579](https://github.com/wppconnect-team/wppconnect/issues/579)) ([ef42485](https://github.com/wppconnect-team/wppconnect/commit/ef42485505e9920b5b7826674949ed9d5e36d4e1))
+- Fixed deleteChat method for multidevice (fix [#586](https://github.com/wppconnect-team/wppconnect/issues/586)) ([1d1e4a1](https://github.com/wppconnect-team/wppconnect/commit/1d1e4a1392a54b89ed1117fab8476b3e71844e69))
+- Fixed logout method ([#579](https://github.com/wppconnect-team/wppconnect/issues/579)) ([ae2fbfb](https://github.com/wppconnect-team/wppconnect/commit/ae2fbfbc047ee71162aa743d74981e6a50e68be8))
+
+## [1.9.2](https://github.com/wppconnect-team/wppconnect/compare/v1.9.1...v1.9.2) (2021-10-12)
+
+### Features
+
+- Added isMultiDevice function (close [#553](https://github.com/wppconnect-team/wppconnect/issues/553)) ([89eeb37](https://github.com/wppconnect-team/wppconnect/commit/89eeb37840f2c2cb46ba538dcabb346ea15cdbb5))
 - Added onRevokedMessage (close [#434](https://github.com/wppconnect-team/wppconnect/issues/434)) ([b5df5bb](https://github.com/wppconnect-team/wppconnect/commit/b5df5bbcc3418204744057cf45089c3bb2228c57))
 
-## 1.9.1 (2021-10-02)
+## [1.9.1](https://github.com/wppconnect-team/wppconnect/compare/v1.9.0...v1.9.1) (2021-10-02)
+
+### Bug Fixes
+
+- Fixed block/unblock contact (fix [#498](https://github.com/wppconnect-team/wppconnect/issues/498)) ([832fceb](https://github.com/wppconnect-team/wppconnect/commit/832fcebfeb72fc7dc595818a3e7b8053cf3494bc))
 
 ### Features
 
 - Added option to use setProfilePic using base64 (close [#505](https://github.com/wppconnect-team/wppconnect/issues/505)) ([87f1841](https://github.com/wppconnect-team/wppconnect/commit/87f184128c2b458f128ff26ac9ea081537b4c2a4))
 
-# 1.9.0 (2021-10-02)
+# [1.9.0](https://github.com/wppconnect-team/wppconnect/compare/v1.8.14...v1.9.0) (2021-10-02)
 
-## 1.8.14 (2021-09-19)
+### Bug Fixes
+
+- Fixed dependency of boxen ([7f9daa0](https://github.com/wppconnect-team/wppconnect/commit/7f9daa04da4aba72d7ca616731f5bb4f73d0d6a1))
+- Fixed getAllMessagesInChat and loadAndGetAllMessagesInChat functions ([4d26a51](https://github.com/wppconnect-team/wppconnect/commit/4d26a51a00a8ec132cc48e38da78e7ce8e0004fe))
+- Fixed getLastSeen on first call ([992710f](https://github.com/wppconnect-team/wppconnect/commit/992710fb962c6e56904ccce5119c7f8d6fa071cc))
+- Fixed getMessages for beta multidevice (fix [#515](https://github.com/wppconnect-team/wppconnect/issues/515)) ([b958442](https://github.com/wppconnect-team/wppconnect/commit/b958442da6eb5e94225ca5cdb4cbc160116b3449))
+- Fixed group members functions ([#438](https://github.com/wppconnect-team/wppconnect/issues/438)) ([c4da6a5](https://github.com/wppconnect-team/wppconnect/commit/c4da6a5b574471b330f46d53372e28b8d4b5bfc1))
+- Fixed return of forwardMessages ([c64c244](https://github.com/wppconnect-team/wppconnect/commit/c64c244f4fce7618fcc0e85845eb83ba24648b2a))
+- Updated whatsapp version ([98d68f1](https://github.com/wppconnect-team/wppconnect/commit/98d68f1d2182dbdc57182fc1c21fbebac9c3cb19))
+- Updated whatsapp version ([bb13ad2](https://github.com/wppconnect-team/wppconnect/commit/bb13ad2b1331510c2363d0f4e29fc9c51eae49de))
+
+### Features
+
+- Added @wppconnect/wa-js ([28264ca](https://github.com/wppconnect-team/wppconnect/commit/28264ca45bb13e68f8a4a4faa427a2d357eba225))
+- Added option to change the connect device name ([64ad7fd](https://github.com/wppconnect-team/wppconnect/commit/64ad7fd58f800893eac4997a73e1944777913b62))
+- Upgraded puppeteer (now allow any version) ([54e1219](https://github.com/wppconnect-team/wppconnect/commit/54e1219e9ad144ea9758c7d86f997e3e00964860))
+
+## [1.8.14](https://github.com/wppconnect-team/wppconnect/compare/v1.8.13...v1.8.14) (2021-09-19)
 
 ### Bug Fixes
 
 - Allow to define chat type in sendMessageOptions (close [#504](https://github.com/wppconnect-team/wppconnect/issues/504)) ([bf76179](https://github.com/wppconnect-team/wppconnect/commit/bf761794559c02a5f7a2d842e68fd6562b68b0cb))
+- Falha ao encerrar sessão no whatsapp beta ([#424](https://github.com/wppconnect-team/wppconnect/issues/424)) ([9d8b81d](https://github.com/wppconnect-team/wppconnect/commit/9d8b81d655ba7043bfb4b457b21a0880d8b69781))
+- Fixed getProfilePicFromServer function and added getWid ([09f70c2](https://github.com/wppconnect-team/wppconnect/commit/09f70c2eea47e81e0c8c3c59bec12565362c74c8))
 
-## 1.8.13 (2021-08-19)
+### Features
+
+- Added option to reply messages and send viewOnce for files ([#499](https://github.com/wppconnect-team/wppconnect/issues/499)) ([db65cfa](https://github.com/wppconnect-team/wppconnect/commit/db65cfae0eb490fe1c08b5550b0db1603c3b429f))
+
+## [1.8.13](https://github.com/wppconnect-team/wppconnect/compare/v1.8.12...v1.8.13) (2021-08-19)
 
 ### Bug Fixes
 
 - Fixed file mime-type detection (fix [#409](https://github.com/wppconnect-team/wppconnect/issues/409)) ([1609e34](https://github.com/wppconnect-team/wppconnect/commit/1609e34e89b02eaba57cd2c0ef17e94393e89916))
+- Fixed getMessages function (fix [#401](https://github.com/wppconnect-team/wppconnect/issues/401)) ([43ba3d4](https://github.com/wppconnect-team/wppconnect/commit/43ba3d436b30fc204b6c0c04ab446af52859835d))
+- Fixed getWAVersion version info ([76a4217](https://github.com/wppconnect-team/wppconnect/commit/76a42170856df6fb8fe97bafb3a5983d529a5358))
+- Fixed message id return for files message ([#419](https://github.com/wppconnect-team/wppconnect/issues/419)) ([e61a605](https://github.com/wppconnect-team/wppconnect/commit/e61a6057d66d556bb35fa3667aaf9c3c72a964ef))
 
-## 1.8.12 (2021-08-05)
+## [1.8.12](https://github.com/wppconnect-team/wppconnect/compare/v1.8.11...v1.8.12) (2021-08-05)
 
-## 1.8.11 (2021-08-04)
+### Bug Fixes
+
+- Fixed reinicialization of WhatsApp Beta Multi-device ([a35994e](https://github.com/wppconnect-team/wppconnect/commit/a35994e560928384bebaaded362c3b592b0f393a))
+- Re-added stopTyping function ([7f93a9c](https://github.com/wppconnect-team/wppconnect/commit/7f93a9cfcdf7a8ffb51d7b05cfd299017bf66b5d))
+
+## [1.8.11](https://github.com/wppconnect-team/wppconnect/compare/v1.8.10...v1.8.11) (2021-08-04)
+
+### Bug Fixes
+
+- Disabled servicework to work with userDataDir ([2ad5954](https://github.com/wppconnect-team/wppconnect/commit/2ad595493167c1f3e2fe45b39de9b06368f84a32))
+- Fixed "'isGroup' of undefined" for group links ([#389](https://github.com/wppconnect-team/wppconnect/issues/389)) ([255db87](https://github.com/wppconnect-team/wppconnect/commit/255db87edaefcefee5de7e2c614f8adb4e8b3124))
+- Fixed setProfilePic function for BETA(multidevice) ([0824b65](https://github.com/wppconnect-team/wppconnect/commit/0824b65db3c62e1175dbf6b193f2cadea6acef55))
+- Fixed startTyping/stopTyping functions ([a122b15](https://github.com/wppconnect-team/wppconnect/commit/a122b15deecfcb6f64c9be57b5d03e9fdfaab119))
 
 ### Features
 
 - Added setOnlinePresence function to define your presence ([627d1a5](https://github.com/wppconnect-team/wppconnect/commit/627d1a5f3a76ea4813420a4fc25784362497da39))
 
-## 1.8.10 (2021-07-31)
+## [1.8.10](https://github.com/wppconnect-team/wppconnect/compare/v1.8.9...v1.8.10) (2021-07-31)
 
 ### Bug Fixes
 
 - Corrigido erro "null to object" ao enviar mensagem (fix [#378](https://github.com/wppconnect-team/wppconnect/issues/378)) ([ec103b9](https://github.com/wppconnect-team/wppconnect/commit/ec103b9cae33b993f95cacdb2a1d35fd3e4ecacc))
+- Corrigido erro "undefined: bundle.encKey" na criação de grupos (fix [#376](https://github.com/wppconnect-team/wppconnect/issues/376)) ([7cb143d](https://github.com/wppconnect-team/wppconnect/commit/7cb143dbb874b1b07f27c344ab0b1bdce60d4224))
+- Corrigido função checkNumberStatus (fix [#372](https://github.com/wppconnect-team/wppconnect/issues/372)) ([2f28945](https://github.com/wppconnect-team/wppconnect/commit/2f289450c5b49349edc9936fd331c44b3d650f63))
+- Melhorado mensagens de erro ao encaminhar (fix [#374](https://github.com/wppconnect-team/wppconnect/issues/374)) ([4da4613](https://github.com/wppconnect-team/wppconnect/commit/4da4613dea6d7e528ecd9a31f88112f535864a28))
+- Melhorado mensagens de retorno de erro ao criar o client (fix [#373](https://github.com/wppconnect-team/wppconnect/issues/373)) ([dde9f83](https://github.com/wppconnect-team/wppconnect/commit/dde9f8354dd76af0baf29ec816dee851e7cbc9f8))
 
-## 1.8.9 (2021-07-27)
+## [1.8.9](https://github.com/wppconnect-team/wppconnect/compare/v1.8.8...v1.8.9) (2021-07-27)
 
 ### Bug Fixes
 
 - Corrigido a função de fixar conversas (pinChat) (fix [#338](https://github.com/wppconnect-team/wppconnect/issues/338)) ([f6bf1f3](https://github.com/wppconnect-team/wppconnect/commit/f6bf1f3f1598719d38eeb9d84bf3a9c0d87de18d))
+- Corrigido id de mensagem retornada no sendText (fix [#364](https://github.com/wppconnect-team/wppconnect/issues/364)) ([3f8561a](https://github.com/wppconnect-team/wppconnect/commit/3f8561a4b857696e0285756fea2c834eb70a2ff8))
+- Corrigido leitura de QR com internet lenta ([e9b1616](https://github.com/wppconnect-team/wppconnect/commit/e9b1616a4ea5438880e2e832807eefd30ac6efa4))
+- Corrigido remoção de token ao fechar ([#316](https://github.com/wppconnect-team/wppconnect/issues/316)) ([450fe5e](https://github.com/wppconnect-team/wppconnect/commit/450fe5eabe38f3600ed938a153c70bd4555f47ba))
+- Corrigido tempo de espera de novo QRCode ([b9e941a](https://github.com/wppconnect-team/wppconnect/commit/b9e941aecea24828515b28b93741cf2d0863d529))
 
-## 1.8.8 (2021-07-27)
+## [1.8.8](https://github.com/wppconnect-team/wppconnect/compare/v1.8.7...v1.8.8) (2021-07-27)
 
 ### Bug Fixes
 
 - Corrigido problema de ES Module (fix [#362](https://github.com/wppconnect-team/wppconnect/issues/362)) ([dcdefc4](https://github.com/wppconnect-team/wppconnect/commit/dcdefc4e7e0dbeb5cd3678ee0b7e7f92e8210dba))
 
-## 1.8.7 (2021-07-26)
+## [1.8.7](https://github.com/wppconnect-team/wppconnect/compare/v1.8.6...v1.8.7) (2021-07-26)
 
-## 1.8.6 (2021-07-23)
+### Features
+
+- Adicionado suporte básico para funcionar com multidevice (BETA) ([6ed3cfb](https://github.com/wppconnect-team/wppconnect/commit/6ed3cfb7716c767f2d9edf33773420cf535c671a))
+
+## [1.8.6](https://github.com/wppconnect-team/wppconnect/compare/v1.8.5...v1.8.6) (2021-07-23)
+
+### Bug Fixes
+
+- Adicionado mensagem quando não informado o ID ([#345](https://github.com/wppconnect-team/wppconnect/issues/345)) ([5b122ea](https://github.com/wppconnect-team/wppconnect/commit/5b122ea511cf19d17525e5c1c32e7a71be5a5a5b))
+- Corrigido todas chamadas que podem gerar UnhandledRejection ([78d7616](https://github.com/wppconnect-team/wppconnect/commit/78d7616c35c23d8dc83932e2b9021aeaa3bdcc2b))
 
 ## [1.8.5](https://github.com/wppconnect-team/wppconnect/compare/v1.8.4...v1.8.5) (2021-07-20)
 
-## 1.8.4 (2021-07-20)
+## [1.8.4](https://github.com/wppconnect-team/wppconnect/compare/v1.8.3...v1.8.4) (2021-07-20)
 
 ### Bug Fixes
 
 - Corrigido o envio de arquivos de tipos de áudio via URL (fix [#329](https://github.com/wppconnect-team/wppconnect/issues/329)) ([6e8b836](https://github.com/wppconnect-team/wppconnect/commit/6e8b836f40ecda9df4870b09d6fc11410a15e1f6))
+- Corrigido problema de impressão da versão do WhatsApp ([6e030d1](https://github.com/wppconnect-team/wppconnect/commit/6e030d167c9e6468d2d5876701cd9f2c719cc5b3))
+- Removido o jsQR ([620706a](https://github.com/wppconnect-team/wppconnect/commit/620706a0726dbb01739464b3534ad2fe3b7791fa))
 
-## 1.8.3 (2021-07-14)
+## [1.8.3](https://github.com/wppconnect-team/wppconnect/compare/v1.8.2...v1.8.3) (2021-07-14)
 
 ### Bug Fixes
 
 - Corrigido disparos de onNotificationMessage e onParticipantsChanged ao iniciar ([d421f7b](https://github.com/wppconnect-team/wppconnect/commit/d421f7bc860ec4cee503340c14e676692094ac1d))
 
-## 1.8.2 (2021-07-14)
+## [1.8.2](https://github.com/wppconnect-team/wppconnect/compare/v1.8.1...v1.8.2) (2021-07-14)
+
+### Bug Fixes
+
+- Corrigido erro de "Promise was collected" ([54b2be7](https://github.com/wppconnect-team/wppconnect/commit/54b2be725723a3d1f5f658fa1d61331c0075e993))
 
 ### Features
 
@@ -653,10 +1378,6 @@
 
 ## [1.5.2](https://github.com/wppconnect-team/wppconnect/compare/v1.5.1...v1.5.2) (2021-05-24)
 
-### Bug Fixes
-
-- Fixed click to reload qr code, Update scrape-img-qr.ts ([a2104e4](https://github.com/wppconnect-team/wppconnect/commit/a2104e4b5bb50a606c90a2d7d42801289f33f2c1)) Thanks to @AlanMartines
-
 ## [1.5.1](https://github.com/wppconnect-team/wppconnect/compare/v1.5.0...v1.5.1) (2021-05-21)
 
 ### Bug Fixes
@@ -717,12 +1438,6 @@
 ### Features
 
 - Added sendGif method to send GIF in the chat ([#112](https://github.com/wppconnect-team/wppconnect/issues/112)) ([4ee590c](https://github.com/wppconnect-team/wppconnect/commit/4ee590c1d0c07bec7d5789deb60f693e0a524192))
-
-## [1.3.4](https://github.com/wppconnect-team/wppconnect/compare/v1.3.3...v1.3.4) (2021-04-30)
-
-### Bug Fixes
-
-- Fixed deletion of tmp chrome user data dir on exit ([8586505](https://github.com/wppconnect-team/wppconnect/commit/85865059810ba9388f172c2ff3b681bae6a3b420))
 
 ## [1.3.3](https://github.com/wppconnect-team/wppconnect/compare/v1.3.2...v1.3.3) (2021-04-28)
 
@@ -846,3 +1561,9 @@
 - Added sendPtt from file ([ae38c8e](https://github.com/wppconnect-team/wppconnect/commit/ae38c8e38c6c8b731b0ceda008c9224b497f42fd))
 
 # [1.0.0](https://github.com/wppconnect-team/wppconnect/compare/v0.0.2...v1.0.0) (2021-02-24)
+
+## [0.0.2](https://github.com/wppconnect-team/wppconnect/compare/aa24a517cc07d28e9415916a1c80052255c4789d...v0.0.2) (2021-01-25)
+
+### Features
+
+- start new repo ([aa24a51](https://github.com/wppconnect-team/wppconnect/commit/aa24a517cc07d28e9415916a1c80052255c4789d))


### PR DESCRIPTION
`CHANGELOG.md` lost most of its content. The v2.2.7 entry lists one bug fix, but `v2.2.6..v2.2.7` carries four. The same truncation goes all the way back to v1.8.2: **104 of the 161 entries hold zero or one bullet**.

| release | in CHANGELOG.md | actually shipped |
| --- | --- | --- |
| 2.2.7 | 1 | 4 |
| 1.35.0 | 1 | 14 |
| 1.28.1 | 1 | 16 |
| 1.17.0 | 1 | 19 |

## Cause

`changelog:update` runs `conventional-changelog -p angular -i CHANGELOG.md -s`, which walks the commits between the previous tag and `HEAD`. `release.yml` checked out at the default depth of 1 — no history, no tags — so the walk saw a single commit and wrote a single bullet. Losing the tags also cost every entry its `compare/vA...vB` link and left the 2025 patch releases rendered as `## <small>1.37.x</small>`.

`publish.yml` already sets `fetch-depth: 0`, which is why the published GitHub release notes looked right while the committed changelog did not.

The generator itself is fine — unlike [wppconnect-team/wa-js#3587](https://github.com/wppconnect-team/wa-js/pull/3587), this repo has no `changelog.config.cjs` and passes `-p angular` on the command line, where `conventional-changelog-cli` actually resolves the preset. Grouping, short hashes and issue links all come out correct.

## Changes

- `.github/workflows/release.yml`: `fetch-depth: 0` on the checkout, so future releases record the whole range.
- `CHANGELOG.md`: regenerated with `-r 0` — 161 releases restored, v0.0.2 included.

## Verification

Regenerated output checked for the failure modes seen in wa-js: no 40-char hashes, no `chore(release)` commits listing themselves, no non-numeric issue links. Entry-by-entry comparison against a fresh `-r 0` run: 161/161 releases match, 0 differing entries.
