### PR TITLE
fix: sticker send resolving undefined

### DIFF
--- a/src/api/layers/sender.layer.ts
+++ b/src/api/layers/sender.layer.ts
@@ -1045,16 +1045,25 @@ export class SenderLayer extends ListenerLayer {
 
     const { webpBase64 } = obj;
 
-    return await evaluateAndReturn(
+    // Map only the fields we need instead of returning the raw result:
+    // `sendMsgResult` carries a non-serializable object from WhatsApp for media
+    // sends and page.evaluate resolves `undefined` for any return value that
+    // JSON cannot serialize. Same reason as the other send methods (see #2792).
+    const sendResult = await evaluateAndReturn(
       this.page,
-      ({ to, webpBase64, options }) => {
-        return WPP.chat.sendFileMessage(to, webpBase64, {
+      async ({ to, webpBase64, options }) => {
+        const result = await WPP.chat.sendFileMessage(to, webpBase64, {
           type: 'sticker',
+          waitForAck: true,
           ...options,
         });
+
+        return { ack: result.ack, id: result.id };
       },
       { to, webpBase64, options }
     );
+
+    return sendResult;
   }
 
   /**
@@ -1141,16 +1150,25 @@ export class SenderLayer extends ListenerLayer {
 
     const { webpBase64 } = obj;
 
-    return await evaluateAndReturn(
+    // Map only the fields we need instead of returning the raw result:
+    // `sendMsgResult` carries a non-serializable object from WhatsApp for media
+    // sends and page.evaluate resolves `undefined` for any return value that
+    // JSON cannot serialize. Same reason as the other send methods (see #2792).
+    const sendResult = await evaluateAndReturn(
       this.page,
-      ({ to, webpBase64, options }) => {
-        return WPP.chat.sendFileMessage(to, webpBase64, {
+      async ({ to, webpBase64, options }) => {
+        const result = await WPP.chat.sendFileMessage(to, webpBase64, {
           type: 'sticker',
+          waitForAck: true,
           ...options,
         });
+
+        return { ack: result.ack, id: result.id };
       },
       { to, webpBase64, options }
     );
+
+    return sendResult;
   }
 
   /**


### PR DESCRIPTION
## Problem

`sendImageAsSticker` and `sendImageAsStickerGif` resolve `undefined` even though the sticker is delivered to the chat.

They are the only send methods that return the **raw** object of `WPP.chat.sendFileMessage` through `page.evaluate`:

```ts
return await evaluateAndReturn(this.page, ({ to, webpBase64, options }) => {
  return WPP.chat.sendFileMessage(to, webpBase64, { type: 'sticker', ...options });
}, { to, webpBase64, options });
```

Since **wa-js 4.5.0** (wppconnect-team/wa-js#3515), `SendMessageReturn.sendMsgResult` is the already resolved `SendMsgResultObject` instead of a pending `Promise` — and `waitForAck` defaults to `true`, so the sticker path always resolves it. For media sends that resolved object is not JSON-serializable, and puppeteer resolves `undefined` for any return value it cannot serialize (it does not throw):

| value inside the returned object | `page.evaluate` result (puppeteer 24.43.1) |
| --- | --- |
| pending `Promise` (wa-js <= 4.4.x) | `{"id":"x","ack":1,"sendMsgResult":{}}` |
| resolved media object (wa-js >= 4.5.0) | `undefined` |

So with wa-js >= 4.5.0 every sticker send resolves `undefined`. Callers that read `result.ack` / `result.id` throw `TypeError: Cannot read properties of undefined` and typically retry the send — delivering the same sticker to the contact two or three times.

This is the exact same failure mode as #2792 (`fix: send media returning undefined`), which fixed it for `sendFile` / `sendPtt` / `sendImage` by mapping the fields inside the page. The two sticker methods were left returning the raw object, so they regressed as soon as wa-js changed the shape of that field.

## Fix

Map `{ ack, id }` inside the page in both sticker methods, like every other send method already does, and make `waitForAck: true` explicit so the returned `ack` is a real ack. A comment records why the mapping exists, so the raw return does not come back in a future refactor.

## Testing

- `tsc --noEmit`, `eslint` and `prettier --check` clean (validated against wa-js 4.6.0 typings).
- Serialization behavior reproduced with the bundled puppeteer (24.43.1): an object carrying a cyclic/class value makes `page.evaluate` resolve `undefined`, while `{ ack, id }` round-trips.
