### PR TITLE
fix: preserve phone link code lifecycle

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -141,13 +141,27 @@ export class HostLayer {
       .catch(() => null);
 
     evaluateAndReturn(this.page, () => {
-      WPP.on('conn.auth_code_change', (window as any).checkQrCode);
-    }).catch(() => null);
-    evaluateAndReturn(this.page, () => {
       WPP.on('conn.main_ready', (window as any).checkInChat);
     }).catch(() => null);
+
+    if (typeof this.options.phoneNumber === 'string') {
+      await evaluateAndReturn(this.page, () => {
+        WPP.on('conn.link_code_change', (window as any).onLinkCode);
+        WPP.on('conn.link_code_expired', (window as any).onLinkCodeExpired);
+        WPP.on('conn.link_code_error', (error) =>
+          (window as any).onLinkCodeError(error.message)
+        );
+      }).catch(() => null);
+      await this.loginByCode(this.options.phoneNumber).catch((error) =>
+        this.log('error', error)
+      );
+    } else {
+      await evaluateAndReturn(this.page, () => {
+        WPP.on('conn.auth_code_change', (window as any).checkQrCode);
+      }).catch(() => null);
+      this.checkQrCode();
+    }
     this.checkInChat();
-    this.checkQrCode();
   }
 
   public async start() {
@@ -167,9 +181,15 @@ export class HostLayer {
     );
 
     await this.page.exposeFunction('checkQrCode', () => this.checkQrCode());
-    /*await this.page.exposeFunction('loginByCode', (phone: string) =>
-      this.loginByCode(phone)
-    );*/
+    await this.page.exposeFunction('onLinkCode', (code: string) =>
+      this.onLinkCode(code)
+    );
+    await this.page.exposeFunction('onLinkCodeExpired', () =>
+      this.log('warn', 'Login by code expired; call refreshLinkCode() to retry')
+    );
+    await this.page.exposeFunction('onLinkCodeError', (message: string) =>
+      this.log('error', `Login by code failed: ${message}`)
+    );
     await this.page.exposeFunction('checkInChat', () => this.checkInChat());
 
     this.checkStartInterval = setInterval(() => this.checkStart(), 5000);
@@ -199,9 +219,6 @@ export class HostLayer {
     if (!result?.urlCode || this.urlCode === result.urlCode) {
       return;
     }
-    if (typeof this.options.phoneNumber === 'string') {
-      return this.loginByCode(this.options.phoneNumber);
-    }
     this.urlCode = result.urlCode;
     this.attempt++;
 
@@ -225,21 +242,32 @@ export class HostLayer {
   }
 
   protected async loginByCode(phone: string) {
-    const code = await evaluateAndReturn(
+    await evaluateAndReturn(
       this.page,
       async ({ phone }) => {
-        return JSON.parse(
-          JSON.stringify(await WPP.conn.genLinkDeviceCodeForPhoneNumber(phone))
-        );
+        await WPP.conn.startLinkDeviceCodeForPhoneNumber(phone);
       },
       { phone }
     );
+  }
+
+  protected onLinkCode(code: string) {
     if (this.options.logQR) {
       this.log('info', `Waiting for Login By Code (Code: ${code})\n`);
     } else {
       this.log('verbose', `Waiting for Login By Code`);
     }
     this.catchLinkCode?.(code);
+  }
+
+  /**
+   * Refreshes the code for the active phone-number linking flow.
+   * @category Host
+   */
+  public async refreshLinkCode(): Promise<string> {
+    return await evaluateAndReturn(this.page, () =>
+      WPP.conn.refreshLinkDeviceCode()
+    );
   }
 
   protected async checkInChat() {

--- a/src/tests/00.phone-link-code.test.ts
+++ b/src/tests/00.phone-link-code.test.ts
@@ -1,0 +1,118 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import * as assert from 'assert';
+import { Page } from 'puppeteer';
+import { HostLayer } from '../api/layers/host.layer';
+
+class TestHostLayer extends HostLayer {
+  private qrSequence = 0;
+
+  public async registerPageListeners() {
+    await this.afterPageScriptInjected();
+  }
+
+  public forwardLinkCode(code: string) {
+    this.onLinkCode(code);
+  }
+
+  public scanQrCode() {
+    return this.checkQrCode();
+  }
+
+  public async getQrCode() {
+    this.qrSequence++;
+    return {
+      base64Image: `qr-image-${this.qrSequence}`,
+      urlCode: `qr-code-${this.qrSequence}`,
+    };
+  }
+
+  public async getWAVersion() {
+    return 'test';
+  }
+
+  public async getWAJSVersion() {
+    return 'test';
+  }
+
+  protected async checkInChat() {}
+}
+
+describe('Phone link code lifecycle', function () {
+  it('does not regenerate the phone link code when the QR code rotates', async function () {
+    const listeners = new Map<string, (...args: any[]) => void>();
+    const receivedCodes: string[] = [];
+    let generationCalls = 0;
+
+    const page = {
+      on: () => page,
+      evaluate: async (pageFunction: (...args: any[]) => any, ...args: any[]) =>
+        pageFunction(...args),
+    } as unknown as Page;
+
+    const client = new TestHostLayer(page, 'phone-link-test', {
+      logQR: false,
+      phoneNumber: '5511999999999',
+    } as any);
+    client.catchLinkCode = (code) => receivedCodes.push(code);
+
+    const previousWPP = (globalThis as any).WPP;
+    const previousWindow = (globalThis as any).window;
+
+    (globalThis as any).window = {
+      checkQrCode: () => client.scanQrCode(),
+      checkInChat: () => undefined,
+      onLinkCode: (code: string) => client.forwardLinkCode(code),
+      onLinkCodeError: () => undefined,
+      onLinkCodeExpired: () => undefined,
+    };
+    (globalThis as any).WPP = {
+      on: (event: string, listener: (...args: any[]) => void) =>
+        listeners.set(event, listener),
+      conn: {
+        isRegistered: () => false,
+        genLinkDeviceCodeForPhoneNumber: async () => {
+          generationCalls++;
+          return `LEGACY${generationCalls}`;
+        },
+        startLinkDeviceCodeForPhoneNumber: async () => {
+          generationCalls++;
+          listeners.get('conn.link_code_change')?.('INITIAL123');
+          return 'INITIAL123';
+        },
+      },
+    };
+
+    try {
+      await client.registerPageListeners();
+
+      await listeners.get('conn.auth_code_change')?.('qr-1');
+      await listeners.get('conn.auth_code_change')?.('qr-2');
+      await listeners.get('conn.auth_code_change')?.('qr-3');
+
+      assert.strictEqual(generationCalls, 1);
+      assert.deepStrictEqual(receivedCodes, ['INITIAL123']);
+
+      listeners.get('conn.link_code_change')?.('REFRESH456');
+      assert.deepStrictEqual(receivedCodes, ['INITIAL123', 'REFRESH456']);
+    } finally {
+      (globalThis as any).WPP = previousWPP;
+      (globalThis as any).window = previousWindow;
+    }
+  });
+});


### PR DESCRIPTION
## Why

Phone-number linking was tied to `conn.auth_code_change`, so every QR-code rotation called `genLinkDeviceCodeForPhoneNumber()` again. This restarted WhatsApp's alternative-linking flow and invalidated the code previously delivered to the user.

WA-JS now provides the managed lifecycle introduced by wppconnect-team/wa-js#3554 and released in v4.6.0. WPPConnect should consume that lifecycle instead of treating QR rotations as phone-code refresh requests.

Fixes #2836.

## What changed

- start phone-number linking once with `startLinkDeviceCodeForPhoneNumber()`
- forward codes from `conn.link_code_change` to `catchLinkCode`
- keep `conn.auth_code_change` exclusive to QR login
- handle managed lifecycle expiration and errors
- expose `refreshLinkCode()` for an explicit manual refresh
- add a regression test proving QR rotations do not regenerate the phone link code

## Verification

- `TS_NODE_FILES=true npx mocha -r ts-node/register src/tests/00.phone-link-code.test.ts`
- `npx eslint src/tests/00.phone-link-code.test.ts src/api/layers/host.layer.ts`
- `npm run build`
- `git diff --check`

The full existing test suite currently stops at `src/tests/01.qrcode.test.ts:71` because it passes an argument to `waitForQrCodeScan()`, whose current signature accepts none; this is unrelated to this change.