### PR TITLE
fix: wait for WAPI reinjection after page loads

### DIFF
--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -48,6 +48,7 @@ export class HostLayer {
 
   protected isInitialized = false;
   protected isInjected = false;
+  protected pageLoadPromise?: Promise<void>;
   protected isStarted = false;
   protected isLogged = false;
   protected isInChat = false;
@@ -88,7 +89,15 @@ export class HostLayer {
 
     this.page.on('load', () => {
       this.log('verbose', 'Page loaded', { type: 'page' });
-      this.afterPageLoad();
+      this.isInjected = false;
+
+      const previousPageLoad = this.pageLoadPromise?.catch(() => undefined);
+      const pageLoad = (previousPageLoad || Promise.resolve()).then(() =>
+        this.afterPageLoad()
+      );
+
+      this.pageLoadPromise = pageLoad;
+      void pageLoad.catch(() => undefined);
     });
 
     this.isInitialized = true;
@@ -113,19 +122,16 @@ export class HostLayer {
       options
     );
 
-    this.isInjected = false;
-
-    await injectApi(this.page, this.onLoadingScreen)
-      .then(() => {
-        this.isInjected = true;
-        this.log('verbose', 'wapi.js injected');
-        this.afterPageScriptInjected();
-      })
-      .catch((e) => {
-        console.log(e);
-        this.log('verbose', 'wapi.js failed');
-        this.log('error', e);
-      });
+    try {
+      await injectApi(this.page, this.onLoadingScreen);
+      this.isInjected = true;
+      this.log('verbose', 'wapi.js injected');
+      this.afterPageScriptInjected();
+    } catch (error) {
+      this.log('verbose', 'wapi.js failed');
+      this.log('error', error);
+      throw error;
+    }
   }
 
   protected async afterPageScriptInjected() {
@@ -378,11 +384,23 @@ export class HostLayer {
   }
 
   public async waitForPageLoad() {
-    while (!this.isInjected) {
-      await sleep(200);
+    while (!this.page.isClosed()) {
+      const pageLoad = this.pageLoadPromise;
+
+      if (!pageLoad) {
+        await sleep(50);
+        continue;
+      }
+
+      await pageLoad;
+
+      if (pageLoad === this.pageLoadPromise && this.isInjected) {
+        await this.page.waitForFunction(() => WPP.isReady);
+        return;
+      }
     }
 
-    await this.page.waitForFunction(() => WPP.isReady).catch(() => {});
+    throw new Error('Page closed before WAPI injection completed');
   }
 
   public async waitForLogin() {
@@ -447,6 +465,7 @@ export class HostLayer {
         this.tryAutoClose();
         throw new Error('Phone not connected');
       }
+      await this.waitForPageLoad();
       this.cancelAutoClose();
       return true;
     }
@@ -520,6 +539,7 @@ export class HostLayer {
    * @category Host
    */
   public async isConnected() {
+    await this.waitForPageLoad();
     return await evaluateAndReturn(this.page, () => WAPI.isConnected());
   }
 

--- a/src/controllers/browser.ts
+++ b/src/controllers/browser.ts
@@ -265,15 +265,13 @@ export async function injectApi(
   });
   await onLoadingScreen(page, onLoadingScreenCallBack);
   // Make sure WAPI is initialized
-  await page
-    .waitForFunction(() => {
-      return (
-        typeof window.WAPI !== 'undefined' &&
-        typeof window.Store !== 'undefined' &&
-        window.WPP.isReady
-      );
-    })
-    .catch(() => false);
+  await page.waitForFunction(() => {
+    return (
+      typeof window.WAPI !== 'undefined' &&
+      typeof window.Store !== 'undefined' &&
+      window.WPP.isReady
+    );
+  });
 }
 
 /**

--- a/src/tests/00.host-layer-page-load.test.ts
+++ b/src/tests/00.host-layer-page-load.test.ts
@@ -1,0 +1,105 @@
+/*
+ * This file is part of WPPConnect.
+ *
+ * WPPConnect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WPPConnect is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with WPPConnect.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import * as assert from 'assert';
+import { Page } from 'puppeteer';
+
+import { HostLayer } from '../api/layers/host.layer';
+import { injectApi } from '../controllers/browser';
+
+class FakePage {
+  evaluateCalls = 0;
+  private listeners = new Map<string, Array<() => void>>();
+
+  on(event: string, listener: () => void) {
+    const listeners = this.listeners.get(event) || [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+
+  emit(event: string) {
+    for (const listener of this.listeners.get(event) || []) {
+      listener();
+    }
+  }
+
+  async evaluate() {
+    this.evaluateCalls += 1;
+    return true;
+  }
+
+  isClosed() {
+    return false;
+  }
+
+  async waitForFunction() {
+    return true;
+  }
+}
+
+class DelayedInjectionHostLayer extends HostLayer {
+  private completeInjection?: () => void;
+
+  protected log() {}
+
+  protected async afterPageLoad() {
+    await new Promise<void>((resolve) => {
+      this.completeInjection = resolve;
+    });
+    this.isInjected = true;
+  }
+
+  finishInjection() {
+    this.completeInjection?.();
+  }
+}
+
+describe('HostLayer page reinjection', function () {
+  it('waits for the current page injection before evaluating WAPI', async function () {
+    const page = new FakePage();
+    const client = new DelayedInjectionHostLayer(
+      page as unknown as Page,
+      'reinjection-test'
+    );
+
+    page.emit('load');
+    const connected = client.isConnected();
+    await Promise.resolve();
+
+    assert.strictEqual(page.evaluateCalls, 0);
+
+    client.finishInjection();
+    assert.strictEqual(await connected, true);
+    assert.strictEqual(page.evaluateCalls, 1);
+  });
+
+  it('propagates a WAPI readiness timeout instead of marking injection complete', async function () {
+    const page = {
+      evaluate: async () => false,
+      addScriptTag: async () => undefined,
+      exposeFunction: async () => undefined,
+      waitForFunction: async () => {
+        throw new Error('WAPI readiness timeout');
+      },
+    };
+
+    await assert.rejects(
+      injectApi(page as unknown as Page),
+      /WAPI readiness timeout/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- serialize WAPI injection work triggered by page `load` events
- make `waitForPageLoad()` await the latest tracked injection instead of polling a stale boolean
- wait for reinjection after login and before `isConnected()` evaluates `WAPI`
- propagate WAPI readiness timeouts instead of marking a failed injection as complete
- add regressions for delayed reinjection and readiness failures

## Root cause

After QR login, WhatsApp Web can reload while `afterPageLoad()` is still reinjecting `wapi.js`. The previous load handler launched that async work without tracking it, so `isConnected()` could evaluate `WAPI.isConnected()` in the new document before `WAPI` existed.

## Validation

- `npm run build`
- targeted ESLint on changed files
- `SKIP_QR_CODE=1 TS_NODE_TRANSPILE_ONLY=true npm test` (3 passing, 42 integration tests pending without credentials)
- regression verified red before the fix and green after it