### PR TITLE
fix(listener): align edit and reaction event types

### DIFF
--- a/src/api/layers/listener.layer.ts
+++ b/src/api/layers/listener.layer.ts
@@ -283,6 +283,7 @@ export class ListenerLayer extends ProfileLayer {
                 msgId: data.msgId,
                 reactionText: data.reactionText,
                 read: data.read,
+                sender: data.sender,
                 orphan: data.orphan,
                 orphanReason: data.orphanReason,
                 timestamp: data.timestamp,
@@ -491,10 +492,11 @@ export class ListenerLayer extends ProfileLayer {
 
   /**
    * @event Listens to message edited changes
+   * @param callback Receives the edited message data
    * @returns Disposable object to stop the listening
    */
   public onMessageEdit(
-    callback: (chat: Wid, id: string, msg: Message) => void
+    callback: (data: { chat: Wid; id: string; msg: Message }) => void
   ) {
     return this.registerEvent(ExposedFn.onMessageEdit, callback);
   }
@@ -716,10 +718,11 @@ export class ListenerLayer extends ProfileLayer {
    */
   public onReactionMessage(
     callback: (data: {
-      id: string;
-      msgId: string;
+      id: MsgKey;
+      msgId: MsgKey;
       reactionText: string;
       read: boolean;
+      sender: Wid;
       orphan: number;
       orphanReason: any;
       timestamp: number;


### PR DESCRIPTION
## Summary
- align `onMessageEdit` with its existing runtime contract: one event object containing `chat`, `id`, and `msg`
- type reaction `id` and `msgId` as the upstream `MsgKey` objects instead of strings
- preserve the upstream reaction `sender` in the public callback payload

This fixes the declaration/runtime mismatches without changing the established `onMessageEdit` runtime payload.

Fixes #2479
Fixes #2734

## Validation
- `npm ci` with `PUPPETEER_SKIP_DOWNLOAD=true`
- `npm run build` (WAPI webpack and TypeScript)
- `npx eslint src/api/layers/listener.layer.ts`
- `git diff --check`

`npm test` still reaches the existing unrelated compile failure in `src/tests/01.qrcode.test.ts:71` (`TS2554: Expected 0 arguments, but got 1`).