### PR TITLE
fix: preserve QR authentication state during navigation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Build source
         run: npm run build
 
+      - name: Test page lifecycle and authentication
+        run: npx mocha -r ts-node/register src/tests/00.host-layer-page-load.test.ts
+        env:
+          TS_NODE_FILES: 'true'
+
       - name: Verify CommonJS entry point
         run: |
           node - <<'NODE'

--- a/src/api/layers/host.layer.ts
+++ b/src/api/layers/host.layer.ts
@@ -214,6 +214,9 @@ export class HostLayer {
   protected async checkQrCode() {
     const needScan = await needsToScan(this.page).catch(() => null);
 
+    // A navigation can invalidate the execution context while waiting for QR.
+    // An unknown result is not proof that the session has registered.
+    if (needScan === null) return;
     this.isLogged = !needScan;
     if (!needScan) {
       this.attempt = 0;
@@ -353,6 +356,7 @@ export class HostLayer {
     while (!this.page.isClosed() && !this.isLogged) {
       await sleep(200);
       const needScan = await needsToScan(this.page).catch(() => null);
+      if (needScan === null) continue;
       this.isLogged = !needScan;
     }
   }
@@ -377,7 +381,7 @@ export class HostLayer {
       }
 
       await sleep(1000);
-      const inChat = isInsideChat(this.page).catch(() => null);
+      const inChat = await isInsideChat(this.page).catch(() => null);
       this.isInChat = !!inChat;
     }
     return this.isInChat;

--- a/src/tests/00.host-layer-page-load.test.ts
+++ b/src/tests/00.host-layer-page-load.test.ts
@@ -103,3 +103,84 @@ describe('HostLayer page reinjection', function () {
     );
   });
 });
+
+class AuthenticationPage extends FakePage {
+  constructor(private results: Array<boolean | Error>) {
+    super();
+  }
+
+  async evaluate() {
+    this.evaluateCalls += 1;
+    const result = this.results.shift();
+    if (result instanceof Error) throw result;
+    return result ?? false;
+  }
+}
+
+class AuthenticationHostLayer extends HostLayer {
+  protected log() {}
+
+  begin(logged = false) {
+    this.isStarted = true;
+    this.isLogged = logged;
+  }
+
+  get logged() {
+    return this.isLogged;
+  }
+
+  readQr() {
+    return this.checkQrCode();
+  }
+}
+
+describe('HostLayer authentication during navigation', function () {
+  this.timeout(5000);
+
+  it('keeps waiting for registration after a destroyed execution context', async function () {
+    const page = new AuthenticationPage([
+      new Error(
+        'Execution context was destroyed, most likely because of a navigation.'
+      ),
+      false,
+      true,
+    ]);
+    const client = new AuthenticationHostLayer(
+      page as unknown as Page,
+      'navigation'
+    );
+    client.begin();
+
+    await client.waitForQrCodeScan();
+
+    assert.strictEqual(page.evaluateCalls, 3);
+    assert.strictEqual(client.logged, true);
+  });
+
+  it('does not mark a QR session authenticated when a QR callback races navigation', async function () {
+    const page = new AuthenticationPage([
+      new Error('Execution context was destroyed'),
+    ]);
+    const client = new AuthenticationHostLayer(
+      page as unknown as Page,
+      'qr-callback'
+    );
+    client.begin();
+
+    await client.readQr();
+
+    assert.strictEqual(client.logged, false);
+  });
+
+  it('waits for the resolved chat readiness value', async function () {
+    const page = new AuthenticationPage([false, true]);
+    const client = new AuthenticationHostLayer(
+      page as unknown as Page,
+      'chat-ready'
+    );
+    client.begin(true);
+
+    assert.strictEqual(await client.waitForInChat(), true);
+    assert.strictEqual(page.evaluateCalls, 2);
+  });
+});


### PR DESCRIPTION
WhatsApp Web navigation can invalidate an authentication evaluation while a session is waiting for its QR code. The client previously interpreted the failed evaluation as successful registration, then closed the session with qrReadError/qrReadFail. Keep waiting when authentication is unknown, and await the actual chat readiness result instead of treating its Promise as true.

Validation: three regressions fail before the change and pass afterwards; all five page lifecycle/authentication tests pass with type checking and now run in CI. Build and targeted lint pass. The broader suite has six passing tests and 42 account/QR-dependent tests skipped when run with TS_NODE_TRANSPILE_ONLY and SKIP_QR_CODE; its existing credential-dependent files have stale TypeScript API calls. A real server reproduction confirmed an execution-context destruction during navigation; live account pairing and message delivery are still pending.
